### PR TITLE
Fix windows path error

### DIFF
--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -34,7 +34,7 @@ def main():
         setup_readline()
 
     print("* Initializing, be patient...\n")
-    os.path.append('.')
+    os.path.join('.')
     from pytorch_lightning import logging
     from ldm.simplet2i import T2I
 


### PR DESCRIPTION
os.path on Windows uses ntpath, which doesn't have an append method. Running it produces

`Traceback (most recent call last):
  File ".\scripts\dream.py", line 277, in <module>
    main()
  File ".\scripts\dream.py", line 37, in main
    os.path.append('.')
AttributeError: module 'ntpath' has no attribute 'append'`

This PR switches to join instead, which should be universal.