### PR TITLE
Fix usage of simplified API in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ lets you create images from a prompt in just three lines of code:
 ~~~~
 from ldm.simplet2i import T2I
 model   = T2I()
-outputs = model.text2image("a unicorn in manhattan")
+outputs = model.txt2img("a unicorn in manhattan")
 ~~~~
 
 Outputs is a list of lists in the format [[filename1,seed1],[filename2,seed2]...]

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -104,7 +104,7 @@ The vast majority of these arguments default to reasonable values.
                  seed=None,
                  cfg_scale=7.5,
                  weights="models/ldm/stable-diffusion-v1/model.ckpt",
-                 config = "configs/latent-diffusion/txt2img-1p4B-eval.yaml",
+                 config = "configs/stable-diffusion/v1-inference.yaml",
                  sampler_name="klms",
                  latent_channels=4,
                  downsampling_factor=8,


### PR DESCRIPTION
The [actual implementation](https://github.com/lstein/stable-diffusion/blob/6d1219deec9052ac3a1d5c99c913d15125a13c34/ldm/simplet2i.py#L29) spells it `txt2img`, not `text2image`.