### PR TITLE
Add simple variant mechanism

### DIFF
--- a/ldm/models/diffusion/ddim.py
+++ b/ldm/models/diffusion/ddim.py
@@ -10,13 +10,17 @@ from ldm.modules.diffusionmodules.util import make_ddim_sampling_parameters, mak
 
 
 class DDIMSampler(object):
-    def __init__(self, model, schedule="linear", **kwargs):
+    def __init__(self, model, schedule="linear", device="cuda", **kwargs):
         super().__init__()
         self.model = model
         self.ddpm_num_timesteps = model.num_timesteps
         self.schedule = schedule
+        self.device = device
 
     def register_buffer(self, name, attr):
+        if type(attr) == torch.Tensor:
+            if attr.device != torch.device(self.device):
+                attr = attr.to(torch.device(self.device))
         setattr(self, name, attr)
 
     def make_schedule(self, ddim_num_steps, ddim_discretize="uniform", ddim_eta=0., verbose=True):

--- a/ldm/models/diffusion/plms.py
+++ b/ldm/models/diffusion/plms.py
@@ -9,13 +9,18 @@ from ldm.modules.diffusionmodules.util import make_ddim_sampling_parameters, mak
 
 
 class PLMSSampler(object):
-    def __init__(self, model, schedule="linear", **kwargs):
+    def __init__(self, model, schedule="linear", device="cuda", **kwargs):
         super().__init__()
         self.model = model
         self.ddpm_num_timesteps = model.num_timesteps
         self.schedule = schedule
+        self.device = device
 
     def register_buffer(self, name, attr):
+        if type(attr) == torch.Tensor:
+            if attr.device != torch.device(self.device):
+                attr = attr.to(torch.device(self.device))
+
         setattr(self, name, attr)
 
     def make_schedule(self, ddim_num_steps, ddim_discretize="uniform", ddim_eta=0., verbose=True):

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -143,7 +143,8 @@ The vast majority of these arguments default to reasonable values.
 
     def txt2img(self,prompt,outdir=None,batch_size=None,iterations=None,
                 steps=None,seed=None,grid=None,individual=None,width=None,height=None,
-                cfg_scale=None,ddim_eta=None,strength=None,init_img=None,skip_normalize=False):
+                cfg_scale=None,ddim_eta=None,strength=None,init_img=None,
+                skip_normalize=False,variants=None):
         """
         Generate an image from the prompt, writing iteration images into the outdir
         The output is a list of lists in the format: [[filename1,seed1], [filename2,seed2],...]
@@ -268,7 +269,7 @@ The vast majority of these arguments default to reasonable values.
     # There is lots of shared code between this and txt2img and should be refactored.
     def img2img(self,prompt,outdir=None,init_img=None,batch_size=None,iterations=None,
                 steps=None,seed=None,grid=None,individual=None,width=None,height=None,
-                cfg_scale=None,ddim_eta=None,strength=None,skip_normalize=False):
+                cfg_scale=None,ddim_eta=None,strength=None,skip_normalize=False,variants=None):
         """
         Generate an image from the prompt and the initial image, writing iteration images into the outdir
         The output is a list of lists in the format: [[filename1,seed1], [filename2,seed2],...]

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -183,8 +183,8 @@ def main_loop(t2i,parser,log,infile):
             newopt = copy.deepcopy(opt)
             newopt.variants = None
             for r in results:
-                newopt.init_img = resultPath = r[0]
-                print(f"\t generating variant for {resultPath}")
+                newopt.init_img = r[0]
+                print(f"\t generating variant for {newopt.init_img}")
                 for j in range(0, opt.variants):
                     try:
                         variantResults = t2i.img2img(**vars(newopt))

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -183,11 +183,9 @@ def main_loop(t2i,parser,log,infile):
             newopt = copy.deepcopy(opt)
             newopt.variants = None
             for r in results:
-                resultPath = r[0]
+                newopt.init_img = resultPath = r[0]
                 print(f"\t generating variant for {resultPath}")
                 for j in range(0, opt.variants):
-                    newopt.init_img = resultPath
-                    print(f"{newopt.init_img}")
                     try:
                         variantResults = t2i.img2img(**vars(newopt))
                         allVariantResults.append([newopt,variantResults])

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -191,16 +191,16 @@ def main_loop(t2i,parser,log,infile):
                     print(f"{newopt.init_img}")
                     try:
                         variantResults = t2i.img2img(**vars(newopt))
+                        allVariantResults.append([newopt,variantResults])
                     except AssertionError as e:
                         print(e)
                         continue
-                    allVariantResults.append([newopt,variantResults])
             print(f"{opt.variants} Variants generated!")
 
         print("Outputs:")
         write_log_message(t2i,opt,results,log)
             
-        if len(allVariantResults)>0:
+        if allVariantResults:
             print("Variant outputs:")
             for vr in allVariantResults:
                 write_log_message(t2i,vr[0],vr[1],log)


### PR DESCRIPTION
This pr adds the following:

 - Introduces a new flag, [-v, --variants] that accepts an int and pipes generated images back through the img2img pipeline in order to have a simple 'variants' method. This obvi has some limitations: works solely on strength, and uses the original prompt, but provides some interesting results
 - Fixes the warning that LANCZOS is deprecated introduced by a different PR
 - Hopefully better resolves the device issue for folks running on different device types in the ddim and plms samplers