### PR TITLE
Remove accelerate library

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,6 @@ dependencies:
   - torchvision=0.12.0
   - numpy=1.19.2
   - pip:
-    - accelerate==0.12.0
     - albumentations==0.4.3
     - opencv-python==4.1.2.30
     - pudb==2019.2

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -1,4 +1,4 @@
-'''wrapper around part of Karen Crownson's k-duffsion library, making it call compatible with other Samplers'''
+'''wrapper around part of Katherine Crowson's k-diffusion library, making it call compatible with other Samplers'''
 import k_diffusion as K
 import torch
 import torch.nn as nn

--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -2,7 +2,6 @@
 import k_diffusion as K
 import torch
 import torch.nn as nn
-import accelerate
 
 class CFGDenoiser(nn.Module):
     def __init__(self, model):
@@ -17,12 +16,11 @@ class CFGDenoiser(nn.Module):
         return uncond + (cond - uncond) * cond_scale
 
 class KSampler(object):
-    def __init__(self,model,schedule="lms", **kwargs):
+    def __init__(self, model, schedule="lms", device="cuda", **kwargs):
         super().__init__()
-        self.model        = K.external.CompVisDenoiser(model)
-        self.accelerator  = accelerate.Accelerator()
-        self.device       = self.accelerator.device
+        self.model = K.external.CompVisDenoiser(model)
         self.schedule = schedule
+        self.device = device
 
         def forward(self, x, sigma, uncond, cond, cond_scale):
             x_in = torch.cat([x] * 2)
@@ -67,8 +65,5 @@ class KSampler(object):
             x = torch.randn([batch_size, *shape], device=self.device) * sigmas[0] # for GPU draw
         model_wrap_cfg = CFGDenoiser(self.model)
         extra_args = {'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': unconditional_guidance_scale}
-        return (K.sampling.__dict__[f'sample_{self.schedule}'](model_wrap_cfg, x, sigmas, extra_args=extra_args, disable=not self.accelerator.is_main_process),
+        return (K.sampling.__dict__[f'sample_{self.schedule}'](model_wrap_cfg, x, sigmas, extra_args=extra_args),
                 None)
-
-    def gather(samples_ddim):
-        return self.accelerator.gather(samples_ddim)

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -467,17 +467,17 @@ The vast majority of these arguments default to reasonable values.
             elif self.sampler_name == 'ddim':
                 self.sampler = DDIMSampler(self.model, device=self.device)
             elif self.sampler_name == 'k_dpm_2_a':
-                self.sampler = KSampler(self.model,'dpm_2_ancestral')
+                self.sampler = KSampler(self.model, 'dpm_2_ancestral', device=self.device)
             elif self.sampler_name == 'k_dpm_2':
-                self.sampler = KSampler(self.model,'dpm_2')
+                self.sampler = KSampler(self.model, 'dpm_2', device=self.device)
             elif self.sampler_name == 'k_euler_a':
-                self.sampler = KSampler(self.model,'euler_ancestral')
+                self.sampler = KSampler(self.model, 'euler_ancestral', device=self.device)
             elif self.sampler_name == 'k_euler':
-                self.sampler = KSampler(self.model,'euler')
+                self.sampler = KSampler(self.model, 'euler', device=self.device)
             elif self.sampler_name == 'k_heun':
-                self.sampler = KSampler(self.model,'heun')
+                self.sampler = KSampler(self.model, 'heun', device=self.device)
             elif self.sampler_name == 'k_lms':
-                self.sampler = KSampler(self.model,'lms')
+                self.sampler = KSampler(self.model, 'lms', device=self.device)
             else:
                 msg = f'unsupported sampler {self.sampler_name}, defaulting to plms'
                 self.sampler = PLMSSampler(self.model, device=self.device)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-accelerate==0.12.0
 albumentations==0.4.3
 einops==0.3.0
 huggingface-hub==0.8.1


### PR DESCRIPTION
This library isn't actually required to be able to use the k-diffusion samplers. It is only part of the demonstration scripts.
There was also a small bug with the txt2img.py, where `x_sample = accelerator.gather(x_samples_ddim)` should have been `x_samples_ddim = accelerator.gather(x_samples_ddim)`, but doesn't matter since accelerate was removed.
KSampler.gather was never called anywhere and seems to just be accelerate related, so removed.
And fixed the attribution on the k-diffusion wrapper.

Tested both the original script and the dream interface, both still work.