### PR TITLE
Properly remove src from repository, add ignored directory for initial images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 outputs/
 models/ldm/stable-diffusion-v1/model.ckpt
 
+# ignore a directory which serves as a place for initial images
+inputs/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
- src was already in the gitignore, but it was still staged in the repo. I ran `git rm -r --cached src`. (when setting the env up, I had to remove src manually or the conda env setup would silently fail and hang) -> conda env setup should work reliably now
- added a directory "inputs" to .gitignore. I like to save my init-img for img2img inside the project directory -> this creates unstaged changes. `inputs/` serves as a directory where initial images can be stored. (should there be a .gitkeep to have the folder after cloning but not create unstaged changes when files get added there?)