### PR TITLE
Clear cuda cache after each image

### DIFF
--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -320,6 +320,7 @@ class T2I:
                             )
                         if torch.cuda.is_available():
                             torch.cuda.empty_cache()
+                            torch.cuda.ipc_collect()
                         results.append([image, seed])
                         if image_callback is not None:
                             image_callback(image, seed)

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -318,6 +318,8 @@ class T2I:
                             print(
                                 f'Error running GFPGAN - Your image was not enhanced.\n{e}'
                             )
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
                         results.append([image, seed])
                         if image_callback is not None:
                             image_callback(image, seed)


### PR DESCRIPTION
Small change to clear the CUDA cache after generation and processing of each image. Memory Utilization seems to be improved with a negligible effect on performance. Metrics captured in issue #112 