### PR TITLE
Dream web server support all flags(and GFPGAN).

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ a few seconds to image generation. However, if can afford a 3090s with
 ## Barebones Web Server
 
 As of version 1.10, this distribution comes with a bare bones web
-server (see screenshot). To use it, run this script by adding the **--web** option.
+server (see screenshot). To use it, run the *dream.py* script by adding the **--web** option.
 
 You can then connect to the server by pointing your web browser at
 http://localhost:9090, or to the network name or IP address of the server.

--- a/README.md
+++ b/README.md
@@ -155,11 +155,7 @@ a few seconds to image generation. However, if can afford a 3090s with
 ## Barebones Web Server
 
 As of version 1.10, this distribution comes with a bare bones web
-server (see screenshot). To use it, run the command:
-
-~~~~
-(ldm) ~/stable-diffusion$ python3 scripts/dream_web.py
-~~~~
+server (see screenshot). To use it, run this script by adding the **--web** option.
 
 You can then connect to the server by pointing your web browser at
 http://localhost:9090, or to the network name or IP address of the server.

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -118,24 +118,8 @@ def main():
     log_path = os.path.join(opt.outdir, 'dream_log.txt')
     with open(log_path, 'a') as log:
         cmd_parser = create_cmd_parser()
-        if (opt.web):
-            print('\n* --web was specified, starting web server...')
-            # Change working directory to the stable-diffusion directory
-            os.chdir(
-                os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..'))
-            )
-
-            # Start server
-            DreamServer.model = t2i
-            dream_server = ThreadingDreamServer(("0.0.0.0", 9090))
-            print("\n\n* Started Stable Diffusion dream server! Point your browser at http://localhost:9090 or use the host's DNS name or IP address. *")
-
-            try:
-                dream_server.serve_forever()
-            except KeyboardInterrupt:
-                pass
-
-            dream_server.server_close()
+        if opt.web:
+            dream_server_loop(t2i)
         else:
             main_loop(t2i, opt.outdir, cmd_parser, log, infile)
         log.close()
@@ -263,6 +247,24 @@ def main_loop(t2i, outdir, parser, log, infile):
 
     print('goodbye!')
 
+def dream_server_loop(t2i):
+    print('\n* --web was specified, starting web server...')
+    # Change working directory to the stable-diffusion directory
+    os.chdir(
+        os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    )
+
+    # Start server
+    DreamServer.model = t2i
+    dream_server = ThreadingDreamServer(("0.0.0.0", 9090))
+    print("\n\n* Started Stable Diffusion dream server! Point your browser at http://localhost:9090 or use the host's DNS name or IP address. *")
+
+    try:
+        dream_server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    dream_server.server_close()
 
 def load_gfpgan_bg_upsampler(bg_upsampler, bg_tile=400):
     import torch

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -111,10 +111,6 @@ def main():
                 print('Error loading GFPGAN:', file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)
 
-    print(
-        "\n* Initialization done! Awaiting your command (-h for help, 'q' to quit, 'cd' to change output dir, 'pwd' to print output dir)..."
-    )
-
     log_path = os.path.join(opt.outdir, 'dream_log.txt')
     with open(log_path, 'a') as log:
         cmd_parser = create_cmd_parser()
@@ -128,6 +124,9 @@ def main():
 
 
 def main_loop(t2i, outdir, parser, log, infile):
+    print(
+        "\n* Initialization done! Awaiting your command (-h for help, 'q' to quit, 'cd' to change output dir, 'pwd' to print output dir)..."
+    )
     """prompt/read/execute loop"""
     done = False
     last_seeds = []
@@ -247,6 +246,7 @@ def main_loop(t2i, outdir, parser, log, infile):
 
     print('goodbye!')
 
+
 def dream_server_loop(t2i):
     print('\n* --web was specified, starting web server...')
     # Change working directory to the stable-diffusion directory
@@ -257,7 +257,8 @@ def dream_server_loop(t2i):
     # Start server
     DreamServer.model = t2i
     dream_server = ThreadingDreamServer(("0.0.0.0", 9090))
-    print("\n\n* Started Stable Diffusion dream server! Point your browser at http://localhost:9090 or use the host's DNS name or IP address. *")
+    print("\nStarted Stable Diffusion dream server!")
+    print("Point your browser at http://localhost:9090 or use the host's DNS name or IP address.")
 
     try:
         dream_server.serve_forever()
@@ -265,6 +266,7 @@ def dream_server_loop(t2i):
         pass
 
     dream_server.server_close()
+
 
 def load_gfpgan_bg_upsampler(bg_upsampler, bg_tile=400):
     import torch

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -453,7 +453,7 @@ def create_argv_parser():
         '--web',
         dest='web',
         action='store_true',
-        help='start in the web server mode.',
+        help='start in web server mode.',
     )
     return parser
 

--- a/scripts/dream_server.py
+++ b/scripts/dream_server.py
@@ -2,22 +2,11 @@ import json
 import base64
 import mimetypes
 import os
-from pytorch_lightning import logging
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-print("Loading model...")
-from ldm.simplet2i import T2I
-model = T2I(sampler_name='k_lms')
-
-# to get rid of annoying warning messages from pytorch
-import transformers
-transformers.logging.set_verbosity_error()
-logging.getLogger("pytorch_lightning").setLevel(logging.ERROR)
-
-print("Initializing model, be patient...")
-model.load_model()
-
 class DreamServer(BaseHTTPRequestHandler):
+    model = None
+
     def do_GET(self):
         if self.path == "/":
             self.send_response(200)
@@ -52,6 +41,7 @@ class DreamServer(BaseHTTPRequestHandler):
         width = int(post_data['width'])
         height = int(post_data['height'])
         cfgscale = float(post_data['cfgscale'])
+        gfpgan_strength = float(post_data['gfpgan_strength'])
         seed = None if int(post_data['seed']) == -1 else int(post_data['seed'])
 
         print(f"Request to generate with prompt: {prompt}")
@@ -59,13 +49,14 @@ class DreamServer(BaseHTTPRequestHandler):
         outputs = []
         if initimg is None:
             # Run txt2img
-            outputs = model.txt2img(prompt,
+            outputs = self.model.txt2img(prompt,
                                     iterations=iterations,
                                     cfg_scale = cfgscale,
                                     width = width,
                                     height = height,
                                     seed = seed,
-                                    steps = steps)
+                                    steps = steps,
+                                    gfpgan_strength = gfpgan_strength)
         else:
             # Decode initimg as base64 to temp file
             with open("./img2img-tmp.png", "wb") as f:
@@ -73,7 +64,7 @@ class DreamServer(BaseHTTPRequestHandler):
                 f.write(base64.b64decode(initimg))
 
                 # Run img2img
-                outputs = model.img2img(prompt,
+                outputs = self.model.img2img(prompt,
                                         init_img = "./img2img-tmp.png",
                                         iterations = iterations,
                                         cfg_scale = cfgscale,
@@ -95,20 +86,6 @@ class DreamServer(BaseHTTPRequestHandler):
         result = {'outputs': outputs}
         self.wfile.write(bytes(json.dumps(result), "utf-8"))
 
-if __name__ == "__main__":
-    # Change working directory to the stable-diffusion directory
-    os.chdir(
-        os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..'))
-    )
-
-    # Start server
-    dream_server = ThreadingHTTPServer(("0.0.0.0", 9090), DreamServer)
-    print("\n\n* Started Stable Diffusion dream server! Point your browser at http://localhost:9090 or use the host's DNS name or IP address. *")
-
-    try:
-        dream_server.serve_forever()
-    except KeyboardInterrupt:
-        pass
-
-    dream_server.server_close()
-
+class ThreadingDreamServer(ThreadingHTTPServer):
+    def __init__(self, server_address):
+        super(ThreadingDreamServer,self).__init__(server_address, DreamServer)

--- a/scripts/dream_server.py
+++ b/scripts/dream_server.py
@@ -86,6 +86,7 @@ class DreamServer(BaseHTTPRequestHandler):
         result = {'outputs': outputs}
         self.wfile.write(bytes(json.dumps(result), "utf-8"))
 
+
 class ThreadingDreamServer(ThreadingHTTPServer):
     def __init__(self, server_address):
-        super(ThreadingDreamServer,self).__init__(server_address, DreamServer)
+        super(ThreadingDreamServer, self).__init__(server_address, DreamServer)

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -52,6 +52,9 @@
           <label title="Set to -1 for random seed" for="seed">Seed:</label>
           <input value="-1" type="number" id="seed" name="seed">
           <button type="button" id="reset">&olarr;</button>
+          <br>
+          <label title="Strenght of the gfpgan algorithm ex: '1', --gfpgan startup flag is required." for="gfpgan_strength">GPFGAN Strength:</label>
+          <input value="1.0" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.01">
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -54,7 +54,7 @@
           <button type="button" id="reset">&olarr;</button>
           <br>
           <label title="Strenght of the gfpgan algorithm ex: '1', --gfpgan startup flag is required." for="gfpgan_strength">GPFGAN Strength:</label>
-          <input value="1.0" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.01">
+          <input value="0.75" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.01">
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>


### PR DESCRIPTION
So this pull request standardize the flags between the DreamServer and the regular application.

With this code the dream.py script must be called with the --web flag to start the web server.

The dream_web.py was renamed to dream_server.py to match the class name inside and avoid peoples used to the old way to call it.

A GFPGAN Strength field was also added to the web interface so it is now possible to use GFPGAN from the web interface if dream.py is started with the --gfpgan --web flags.

This should mostly cover the request here: https://github.com/lstein/stable-diffusion/issues/123

Cheers.