### PR TITLE
Switch to event based/callback based approach for dream web

### DIFF
--- a/ldm/models/diffusion/ksampler.py
+++ b/ldm/models/diffusion/ksampler.py
@@ -61,6 +61,9 @@ class KSampler(object):
         # this has to come in the same format as the conditioning, # e.g. as encoded tokens, ...
         **kwargs,
     ):
+        def route_callback(k_callback_values):
+            if img_callback is not None:
+                img_callback(k_callback_values['x'], k_callback_values['i'])
 
         sigmas = self.model.get_sigmas(S)
         if x_T:
@@ -78,7 +81,8 @@ class KSampler(object):
         }
         return (
             K.sampling.__dict__[f'sample_{self.schedule}'](
-                model_wrap_cfg, x, sigmas, extra_args=extra_args
+                model_wrap_cfg, x, sigmas, extra_args=extra_args,
+                callback=route_callback
             ),
             None,
         )

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -202,6 +202,7 @@ class T2I:
         ddim_eta=None,
         skip_normalize=False,
         image_callback=None,
+        step_callback=None,
         # these are specific to txt2img
         width=None,
         height=None,
@@ -228,9 +229,14 @@ class T2I:
            gfpgan_strength                 // strength for GFPGAN. 0.0 preserves image exactly, 1.0 replaces it completely
            ddim_eta                        // image randomness (eta=0.0 means the same seed always produces the same image)
            variants                        // if >0, the 1st generated image will be passed back to img2img to generate the requested number of variants
+           step_callback                   // a function or method that will be called each step
            image_callback                  // a function or method that will be called each time an image is generated
 
-        To use the callback, define a function of method that receives two arguments, an Image object
+        To use the step callback, define a function that receives two arguments:
+        - Image GPU data
+        - The step number
+
+        To use the image callback, define a function of method that receives two arguments, an Image object
         and the seed. You can then do whatever you like with the image, including converting it to
         different formats and manipulating it. For example:
 
@@ -285,6 +291,7 @@ class T2I:
                     skip_normalize=skip_normalize,
                     init_img=init_img,
                     strength=strength,
+                    callback=step_callback,
                 )
             else:
                 images_iterator = self._txt2img(
@@ -297,6 +304,7 @@ class T2I:
                     skip_normalize=skip_normalize,
                     width=width,
                     height=height,
+                    callback=step_callback,
                 )
 
             with scope(self.device.type), self.model.ema_scope():
@@ -348,6 +356,7 @@ class T2I:
         skip_normalize,
         width,
         height,
+        callback,
     ):
         """
         An infinite iterator of images from the prompt.
@@ -371,6 +380,7 @@ class T2I:
                 unconditional_guidance_scale=cfg_scale,
                 unconditional_conditioning=uc,
                 eta=ddim_eta,
+                img_callback=callback
             )
             yield self._samples_to_images(samples)
 
@@ -386,6 +396,7 @@ class T2I:
         skip_normalize,
         init_img,
         strength,
+        callback, # Currently not implemented for img2img
     ):
         """
         An infinite iterator of images from the prompt and the initial image

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -55,8 +55,9 @@
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>
+      <br>
+      <progress id="progress" value="0" max="1"></progress>
     </div>
-    <hr>
     <div id="results">
       <div id="no-results-message">
         <i><p>No results...</p></i>

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -59,11 +59,12 @@ async function generateSubmit(form) {
         method: form.method,
         body: JSON.stringify(formData),
     }).then(async (response) => {
-        const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+        const reader = response.body.getReader();
 
         let noOutputs = true;
         while (true) {
-            const {value, done} = await reader.read();
+            let {value, done} = await reader.read();
+            value = new TextDecoder().decode(value);
             if (done) break;
 
             for (let event of value.split('\n').filter(e => e !== '')) {

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -7,12 +7,11 @@ function toBase64(file) {
     });
 }
 
-function appendOutput(output) {
+function appendOutput(src, seed, config) {
     let outputNode = document.createElement("img");
-    outputNode.src = output[0];
+    outputNode.src = src;
 
-    let outputConfig = output[2];
-    let altText = output[1].toString() + " | " + outputConfig.prompt;
+    let altText = seed.toString() + " | " + config.prompt;
     outputNode.alt = altText;
     outputNode.title = altText;
 
@@ -20,20 +19,14 @@ function appendOutput(output) {
     outputNode.addEventListener('click', () => {
         let form = document.querySelector("#generate-form");
         for (const [k, v] of new FormData(form)) {
-            form.querySelector(`*[name=${k}]`).value = outputConfig[k];
+            form.querySelector(`*[name=${k}]`).value = config[k];
         }
-        document.querySelector("#seed").value = output[1];
+        document.querySelector("#seed").value = seed;
 
         saveFields(document.querySelector("#generate-form"));
     });
 
     document.querySelector("#results").prepend(outputNode);
-}
-
-function appendOutputs(outputs) {
-    for (const output of outputs) {
-        appendOutput(output);
-    }
 }
 
 function saveFields(form) {
@@ -59,20 +52,37 @@ async function generateSubmit(form) {
     let formData = Object.fromEntries(new FormData(form));
     formData.initimg = formData.initimg.name !== '' ? await toBase64(formData.initimg) : null;
 
-    // Post as JSON
+    // Post as JSON, using Fetch streaming to get results
     fetch(form.action, {
         method: form.method,
         body: JSON.stringify(formData),
-    }).then(async (result) => {
-        let data = await result.json();
+    }).then(async (response) => {
+        const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+
+        let noOutputs = true;
+        while (true) {
+            const {value, done} = await reader.read();
+            if (done) break;
+
+            for (let event of value.split('\n').filter(e => e !== '')) {
+                const data = JSON.parse(event);
+
+                if (data.event == 'result') {
+                    noOutputs = false;
+
+                    for (let [file, seed] of data.files) {
+                        appendOutput(file, seed, data.config)
+                    }
+                }
+            }
+        }
 
         // Re-enable form, remove no-results-message
         form.querySelector('fieldset').removeAttribute('disabled');
         document.querySelector("#prompt").value = prompt;
 
-        if (data.outputs.length != 0) {
+        if (!noOutputs) {
             document.querySelector("#no-results-message")?.remove();
-            appendOutputs(data.outputs);
         } else {
             alert("Error occurred while generating.");
         }

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -52,6 +52,8 @@ async function generateSubmit(form) {
     let formData = Object.fromEntries(new FormData(form));
     formData.initimg = formData.initimg.name !== '' ? await toBase64(formData.initimg) : null;
 
+    document.querySelector('progress').setAttribute('max', formData.steps);
+
     // Post as JSON, using Fetch streaming to get results
     fetch(form.action, {
         method: form.method,
@@ -69,10 +71,13 @@ async function generateSubmit(form) {
 
                 if (data.event == 'result') {
                     noOutputs = false;
+                    document.querySelector("#no-results-message")?.remove();
 
                     for (let [file, seed] of data.files) {
-                        appendOutput(file, seed, data.config)
+                        appendOutput(file, seed, data.config);
                     }
+                } else if (data.event == 'step') {
+                    document.querySelector('progress').setAttribute('value', data.step.toString());
                 }
             }
         }
@@ -80,10 +85,9 @@ async function generateSubmit(form) {
         // Re-enable form, remove no-results-message
         form.querySelector('fieldset').removeAttribute('disabled');
         document.querySelector("#prompt").value = prompt;
+        document.querySelector('progress').setAttribute('value', '0');
 
-        if (!noOutputs) {
-            document.querySelector("#no-results-message")?.remove();
-        } else {
+        if (noOutputs) {
             alert("Error occurred while generating.");
         }
     });


### PR DESCRIPTION
This uses HTTP fetch streaming to push images to the web interface as they are generated, and adds a progress bar by exposing the img_callback parameter to `prompt2image`.

As a result of using a callback based approach, when generating multiple images, it will add them to the result list immediately, rather than waiting until all images have completed.