### PR TITLE
prevent directory traversal in the web UI

### DIFF
--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -14,8 +14,14 @@ class DreamServer(BaseHTTPRequestHandler):
             self.end_headers()
             with open("./static/dream_web/index.html", "rb") as content:
                 self.wfile.write(content.read())
-        elif os.path.exists("." + self.path):
-            mime_type = mimetypes.guess_type(self.path)[0]
+        else:
+            path = "." + self.path
+            cwd = os.getcwd()
+            is_in_cwd = os.path.commonprefix((os.path.realpath(path), cwd)) == cwd
+            if not (is_in_cwd and os.path.exists(path)):
+                self.send_response(404)
+                return
+            mime_type = mimetypes.guess_type(path)[0]
             if mime_type is not None:
                 self.send_response(200)
                 self.send_header("Content-type", mime_type)
@@ -24,8 +30,6 @@ class DreamServer(BaseHTTPRequestHandler):
                     self.wfile.write(content.read())
             else:
                 self.send_response(404)
-        else:
-            self.send_response(404)
 
     def do_POST(self):
         self.send_response(200)

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -53,7 +53,7 @@
           <input value="-1" type="number" id="seed" name="seed">
           <button type="button" id="reset">&olarr;</button>
           <br>
-          <label title="Strenght of the gfpgan algorithm ex: '1', --gfpgan startup flag is required." for="gfpgan_strength">GPFGAN Strength:</label>
+          <label title="Strength of the gfpgan algorithm ex: '1', --gfpgan startup flag is required." for="gfpgan_strength">GPFGAN Strength:</label>
           <input value="0.75" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.01">
         </fieldset>
       </form>


### PR DESCRIPTION
It's probably not a good idea to run the web UI anywhere an untrusted device could access it. But even so, best not to have this sort of vulnerability.

You might plausibly want to restrict this further, e.g. by not exposing stuff like `dream_log.txt`.