### PR TITLE
Fix sampler changer not working.

### DIFF
--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -212,7 +212,7 @@ class T2I:
         save_original=False,
         upscale=None,
         variants=None,
-        user_sampler=None,
+        sampler_name=None,
         **args,
     ):   # eat up additional cruft
         """
@@ -272,8 +272,8 @@ class T2I:
 
         scope = autocast if self.precision == 'autocast' else nullcontext
 
-        if user_sampler and (user_sampler != self.sampler_name):
-            self.sampler_name = user_sampler
+        if sampler_name and (sampler_name != self.sampler_name):
+            self.sampler_name = sampler_name
             self._set_sampler()
 
         tic = time.time()


### PR DESCRIPTION
Sampler changer is no longer working because the variable was changed in dream.py to support -A ..Fixed that up with this PR. @lstein 