### PR TITLE
Bugfixes to image generation logic

### DIFF
--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager, nullcontext
 import transformers
 import time
 import re
+import sys
 
 from ldm.util import instantiate_from_config
 from ldm.models.diffusion.ddim import DDIMSampler
@@ -540,6 +541,9 @@ class T2I:
                 # model.to doesn't change the cond_stage_model.device used to move the tokenizer output, so set it here
                 self.model.cond_stage_model.device = self.device
             except AttributeError:
+                import traceback
+                print('Error loading model. Only the CUDA backend is supported',file=sys.stderr)
+                print(traceback.format_exc(),file=sys.stderr)
                 raise SystemExit
 
             self._set_sampler()

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -175,8 +175,6 @@ class T2I:
             outdir, prompt, kwargs.get('batch_size', self.batch_size)
         )
         for r in results:
-            # gets written into the PNG
-            metadata_str = f'prompt2png("{prompt}" {kwargs} seed={r[1]}'
             pngwriter.write_image(r[0], r[1])
         return pngwriter.files_written
 

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -350,6 +350,8 @@ class T2I:
                                 image_callback(image, seed)
                             else:
                                 image_callback(image, seed, upscaled=True)
+                        else: # no callback passed, so we simply replace old image with rescaled one
+                            result[0] = image
 
         except KeyboardInterrupt:
             print('*interrupted*')

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -180,11 +180,11 @@ class T2I:
         return pngwriter.files_written
 
     def txt2img(self, prompt, **kwargs):
-        outdir = kwargs.get('outdir', 'outputs/img-samples')
+        outdir = kwargs.pop('outdir', 'outputs/img-samples')
         return self.prompt2png(prompt, outdir, **kwargs)
 
     def img2img(self, prompt, **kwargs):
-        outdir = kwargs.get('outdir', 'outputs/img-samples')
+        outdir = kwargs.pop('outdir', 'outputs/img-samples')
         assert (
             'init_img' in kwargs
         ), 'call to img2img() must include the init_img argument'


### PR DESCRIPTION
Three commits to fix bugs that only appear when calling convenience methods directly.
1. The outdir was not being correctly passed from txt2img() and img2img() to prompt2png
2. On non-CUDA systems, load_model() was failing silently. Now it reports the error with a traceback.
3. When GFPGAN and/or upscaling in use, the modified image was not being returned in the method results list from prompt2image() (it was being passed to callback, which is why nobody spotted the problem). This is now fixed.
4. Unused variable on simplet2i.py Line 129 now removed.