### PR TITLE
FEAT: Dream web upscaling

### DIFF
--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -46,6 +46,9 @@ class DreamServer(BaseHTTPRequestHandler):
         height = int(post_data['height'])
         cfgscale = float(post_data['cfgscale'])
         gfpgan_strength = float(post_data['gfpgan_strength'])
+        upscale_level    = post_data['upscale_level']
+        upscale_strength = post_data['upscale_strength']
+        upscale = [int(upscale_level),float(upscale_strength)] if upscale_level != '' else None
         seed = None if int(post_data['seed']) == -1 else int(post_data['seed'])
 
         print(f"Request to generate with prompt: {prompt}")
@@ -60,7 +63,9 @@ class DreamServer(BaseHTTPRequestHandler):
                                     height = height,
                                     seed = seed,
                                     steps = steps,
-                                    gfpgan_strength = gfpgan_strength)
+                                    gfpgan_strength = gfpgan_strength,
+                                    upscale         = upscale
+            )
         else:
             # Decode initimg as base64 to temp file
             with open("./img2img-tmp.png", "wb") as f:
@@ -74,7 +79,9 @@ class DreamServer(BaseHTTPRequestHandler):
                                          cfg_scale = cfgscale,
                                          seed = seed,
                                          gfpgan_strength=gfpgan_strength,
-                                         steps = steps)
+                                         upscale         = upscale,
+                                         steps = steps
+            )
             # Remove the temp file
             os.remove("./img2img-tmp.png")
 

--- a/static/dream_web/index.css
+++ b/static/dream_web/index.css
@@ -32,6 +32,9 @@ fieldset {
     padding: 5px 10px 5px 10px;
     border: 1px solid black;
 }
+#reset-all {
+    background-color: pink;
+}
 #results {
     text-align: center;
     max-width: 1000px;
@@ -48,7 +51,7 @@ img {
     line-height:2em;
 }
 input[type="number"] {
-    width: 30px;
+    width: 60px;
 }
 #seed {
     width: 150px;

--- a/static/dream_web/index.css
+++ b/static/dream_web/index.css
@@ -48,7 +48,7 @@ img {
     line-height:2em;
 }
 input[type="number"] {
-    width: 60px;
+    width: 30px;
 }
 #seed {
     width: 150px;

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -53,8 +53,17 @@
           <input value="-1" type="number" id="seed" name="seed">
           <button type="button" id="reset">&olarr;</button>
           <br>
-          <label title="Strength of the gfpgan algorithm ex: '1', --gfpgan startup flag is required." for="gfpgan_strength">GPFGAN Strength:</label>
-          <input value="0.75" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.01">
+	  <p><em>The options below require the GFPGAN and ESRGAN packages to be installed</em></p>
+          <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength:</label>
+          <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.1">
+          <label title="Upscaling to perform using ESRGAN." for="upscaling">Upscaling Level</label>
+          <select id="upscaling" name="upscaling" value="">
+            <option value=""></option>
+	    <option value="2">2x</option>
+	    <option value="4">4x</option>
+	  </select>
+          <label title="Strength of the esrgan (upscaling) algorithm." for="esrgan_strength">ESRGAN Strength:</label>
+          <input value="0.75" min="0" max="1" type="number" id="esrgan_strength" name="esrgan_strength" step="0.1">
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -18,12 +18,22 @@
         </fieldset>
         <fieldset id="fieldset-config">
           <label for="iterations">Images to generate:</label>
-          <input value="1" type="number" id="iterations" name="iterations">
+          <input value="1" type="number" id="iterations" name="iterations" size="4">
           <label for="steps">Steps:</label>
           <input value="50" type="number" id="steps" name="steps">
           <label for="cfgscale">Cfg Scale:</label>
           <input value="7.5" type="number" id="cfgscale" name="cfgscale" step="any">
-          <span>&bull;</span>
+          <label for="sampler">Sampler:</label>
+          <select id="sampler" name="sampler" value="k_lms">
+            <option value="ddim">DDIM</option>
+	    <option value="plms">PLMS</option>
+            <option value="k_lms">KLMS</option>
+            <option value="k_dpm_2">KDPM_2</option>
+	    <option value="k_dpm_2_a">KDPM_2A</option>
+	    <option value="k_euler">KEULER</option>
+	    <option value="k_heun">KHEUN</option>
+	  </select>
+	  <br>
           <label title="Set to multiple of 64" for="width">Width:</label>
           <select id="width" name="width" value="512">
             <option value="64">64</option> <option value="128">128</option>
@@ -52,10 +62,12 @@
           <label title="Set to -1 for random seed" for="seed">Seed:</label>
           <input value="-1" type="number" id="seed" name="seed">
           <button type="button" id="reset">&olarr;</button>
+	  <span>&bull;</span>
+	  <button type="button" id="reset-all">Reset to Defaults</button>
           <br>
 	  <p><em>The options below require the GFPGAN and ESRGAN packages to be installed</em></p>
           <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength:</label>
-          <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.1">
+          <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.05">
           <label title="Upscaling to perform using ESRGAN." for="upscaling">Upscaling Level</label>
           <select id="upscaling" name="upscaling" value="">
             <option value=""></option>
@@ -63,7 +75,7 @@
 	    <option value="4">4x</option>
 	  </select>
           <label title="Strength of the esrgan (upscaling) algorithm." for="esrgan_strength">ESRGAN Strength:</label>
-          <input value="0.75" min="0" max="1" type="number" id="esrgan_strength" name="esrgan_strength" step="0.1">
+          <input value="0.75" min="0" max="1" type="number" id="esrgan_strength" name="esrgan_strength" step="0.05">
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -68,14 +68,14 @@
 	  <p><em>The options below require the GFPGAN and ESRGAN packages to be installed</em></p>
           <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength:</label>
           <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.05">
-          <label title="Upscaling to perform using ESRGAN." for="upscaling">Upscaling Level</label>
-          <select id="upscaling" name="upscaling" value="">
+          <label title="Upscaling to perform using ESRGAN." for="upscale_level">Upscaling Level</label>
+          <select id="upscale_level" name="upscale_level" value="">
             <option value=""></option>
 	    <option value="2">2x</option>
 	    <option value="4">4x</option>
 	  </select>
-          <label title="Strength of the esrgan (upscaling) algorithm." for="esrgan_strength">ESRGAN Strength:</label>
-          <input value="0.75" min="0" max="1" type="number" id="esrgan_strength" name="esrgan_strength" step="0.05">
+          <label title="Strength of the esrgan (upscaling) algorithm." for="upscale_strength">Upscale Strength:</label>
+          <input value="0.75" min="0" max="1" type="number" id="upscale_strength" name="upscale_strength" step="0.05">
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -27,7 +27,7 @@
           <select id="sampler" name="sampler" value="k_lms">
             <option value="ddim">DDIM</option>
 	    <option value="plms">PLMS</option>
-            <option value="k_lms">KLMS</option>
+            <option value="k_lms" selected>KLMS</option>
             <option value="k_dpm_2">KDPM_2</option>
 	    <option value="k_dpm_2_a">KDPM_2A</option>
 	    <option value="k_euler">KEULER</option>
@@ -70,7 +70,7 @@
           <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.05">
           <label title="Upscaling to perform using ESRGAN." for="upscale_level">Upscaling Level</label>
           <select id="upscale_level" name="upscale_level" value="">
-            <option value=""></option>
+            <option value="" selected></option>
 	    <option value="2">2x</option>
 	    <option value="4">4x</option>
 	  </select>

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -43,6 +43,7 @@ function saveFields(form) {
         }
     }
 }
+
 function loadFields(form) {
     for (const [k, v] of new FormData(form)) {
         const item = localStorage.getItem(k);
@@ -50,6 +51,11 @@ function loadFields(form) {
             form.querySelector(`*[name=${k}]`).value = item;
         }
     }
+}
+
+function clearFields(form) {
+    localStorage.clear()
+    form.reset()
 }
 
 async function generateSubmit(form) {
@@ -96,6 +102,9 @@ window.onload = () => {
     document.querySelector("#reset").addEventListener('click', (e) => {
         document.querySelector("#seed").value = -1;
         saveFields(e.target.form);
+    });
+    document.querySelector("#reset-all").addEventListener('click', (e) => {
+        clearFields(e.target.form);
     });
     loadFields(document.querySelector("#generate-form"));
 };

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -55,7 +55,7 @@ function loadFields(form) {
 
 function clearFields(form) {
     localStorage.clear()
-    form.reset()
+    location.reload()
 }
 
 async function generateSubmit(form) {


### PR DESCRIPTION
This PR adds the following features to the original (non-incremental) version of the dream web server:
1. Adds support for scaling and face reconstruction.
2. Adds a "reset to defaults" button for returning all form fields to their default values.
This closes issues #167 and #157.

However, it requires bugfix PR #177 for the image scaling and face reconstruction to work properly.