### PR TITLE
web ui: display in-progress images

### DIFF
--- a/ldm/dream/pngwriter.py
+++ b/ldm/dream/pngwriter.py
@@ -73,6 +73,7 @@ class PngWriter:
                     if upscaled:
                         break
                     filename = f'{basecount:06}.{seed}.{series:02}.png'
+                path = os.path.join(self.outdir, filename)
                 finished = not os.path.exists(path)
             return os.path.join(self.outdir, filename)
 

--- a/static/dream_web/index.css
+++ b/static/dream_web/index.css
@@ -46,7 +46,7 @@ fieldset {
     margin: auto;
     padding-top: 10px;
 }
-img {
+#results img {
     cursor: pointer;
     height: 30vh;
     border-radius: 5px;
@@ -66,4 +66,11 @@ hr {
 }
 label {
     white-space: nowrap;
+}
+#progress-section {
+    display: none;
+}
+#progress-image {
+    width: 30vh;
+    height: 30vh;
 }

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -67,6 +67,9 @@
           <button type="button" id="reset-seed">&olarr;</button>
           <span>&bull;</span>
           <button type="button" id="reset-all">Reset to Defaults</button>
+          <br>
+          <label for="progress_images">Display in-progress images (slows down generation):</label>
+          <input type="checkbox" name="progress_images" id="progress_images">
           <div id="gfpgan">
             <p><em>The options below require the GFPGAN and ESRGAN packages to be installed</em></p>
             <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength:</label>
@@ -83,10 +86,13 @@
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>
-      <br>
-      <progress id="progress" value="0" max="1"></progress>
-      <div id="scaling-inprocess-message">
-        <i><span>Postprocessing...</span><span id="processing_cnt">1/3</span></i>
+      <div id="progress-section">
+        <progress id="progress-bar" value="0" max="1"></progress>
+        <br>
+        <img id="progress-image" src='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>'></img>
+        <div id="scaling-inprocess-message">
+          <i><span>Postprocessing...</span><span id="processing_cnt">1/3</span></i>
+        </div>
       </div>
     </div>
     <div id="results">


### PR DESCRIPTION
~Based on #180. Merge that PR first even if you intend to accept this one. Only look at the second commit; the first commit is in #180.~

This adds an off-by-default checkbox which lets you see images as they render, at the cost of slowing down generation. Doing this on every step ~doubles the time-to-generate on my machine, so I've made it do every 5th image, which seemed like a good tradeoff.