### PR TITLE
webui: hide gfpgan part if not installed

### DIFF
--- a/ldm/gfpgan/gfpgan_tools.py
+++ b/ldm/gfpgan/gfpgan_tools.py
@@ -10,16 +10,18 @@ from scripts.dream import create_argv_parser
 arg_parser = create_argv_parser()
 opt = arg_parser.parse_args()
 
+model_path = os.path.join(opt.gfpgan_dir, opt.gfpgan_model_path)
+gfpgan_model_exists = os.path.isfile(model_path)
 
 def _run_gfpgan(image, strength, prompt, seed, upsampler_scale=4):
     print(f'\n* GFPGAN - Restoring Faces: {prompt} : seed:{seed}')
+    gfpgan = None
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=DeprecationWarning)
         warnings.filterwarnings('ignore', category=UserWarning)
 
         try:
-            model_path = os.path.join(opt.gfpgan_dir, opt.gfpgan_model_path)
-            if not os.path.isfile(model_path):
+            if not gfpgan_model_exists:
                 raise Exception('GFPGAN model not found at path ' + model_path)
 
             sys.path.append(os.path.abspath(opt.gfpgan_dir))

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="static/dream_web/index.css">
+    <script src="config.js"></script>
     <script src="static/dream_web/index.js"></script>
   </head>
   <body>
@@ -66,18 +67,19 @@
           <button type="button" id="reset-seed">&olarr;</button>
           <span>&bull;</span>
           <button type="button" id="reset-all">Reset to Defaults</button>
-          <br>
-          <p><em>The options below require the GFPGAN and ESRGAN packages to be installed</em></p>
-          <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength:</label>
-          <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.05">
-          <label title="Upscaling to perform using ESRGAN." for="upscale_level">Upscaling Level</label>
-          <select id="upscale_level" name="upscale_level" value="">
-            <option value="" selected>None</option>
-            <option value="2">2x</option>
-            <option value="4">4x</option>
-          </select>
-          <label title="Strength of the esrgan (upscaling) algorithm." for="upscale_strength">Upscale Strength:</label>
-          <input value="0.75" min="0" max="1" type="number" id="upscale_strength" name="upscale_strength" step="0.05">
+          <div id="gfpgan">
+            <p><em>The options below require the GFPGAN and ESRGAN packages to be installed</em></p>
+            <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength:</label>
+            <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.05">
+            <label title="Upscaling to perform using ESRGAN." for="upscale_level">Upscaling Level</label>
+            <select id="upscale_level" name="upscale_level" value="">
+              <option value="" selected>None</option>
+              <option value="2">2x</option>
+              <option value="4">4x</option>
+            </select>
+            <label title="Strength of the esrgan (upscaling) algorithm." for="upscale_strength">Upscale Strength:</label>
+            <input value="0.75" min="0" max="1" type="number" id="upscale_strength" name="upscale_strength" step="0.05">
+          </div>
         </fieldset>
       </form>
       <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -126,4 +126,8 @@ window.onload = () => {
         clearFields(e.target.form);
     });
     loadFields(document.querySelector("#generate-form"));
+
+    if (!config.gfpgan_model_exists) {
+        document.querySelector("#gfpgan").style.display = 'none';
+    }
 };


### PR DESCRIPTION
This has the first two commits from https://github.com/lstein/stable-diffusion/pull/186 just to avoid merge conflicts. Third commit is the actual logic.

This hides the GFPGAN part of the web UI (and suppresses error messages in the server console) if the GFPGAN model isn't found. I actually don't have GFPGAN installed and so can't test that it still displays when the model actually is installed, but it should.