### PR TITLE
Update simplet2i.py

### DIFF
--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -126,7 +126,7 @@ class T2I:
         grid=False,
         width=512,
         height=512,
-        sampler_name='klms',
+        sampler_name='k_lms',
         latent_channels=4,
         downsampling_factor=8,
         ddim_eta=0.0,  # deterministic


### PR DESCRIPTION
Typo causing bug when preinitializing the model. Unsupported Sampler: klms, Defaulting to plms