### PR TITLE
Add Resolution Checker

### DIFF
--- a/ldm/dream/image_util.py
+++ b/ldm/dream/image_util.py
@@ -49,6 +49,8 @@ class InitImageResizer():
         new_image = Image.new('RGB',(width,height))
         new_image.paste(resized_image,((width-rw)//2,(height-rh)//2))
 
+        print(f'>> Resized image size to {width}x{height}')
+
         return new_image
 
             


### PR DESCRIPTION
Follow up to ##214 by @lstein 

Here's what this PR does.

**txt2img**

- When a user explicitly supplies either `-W` or `-H`, it performs a check to see if the resolution is a multiple of 64. If it is not, then it will change the resolution to the closest compatible number -- for both width and height or just one depending on what is set. The other will be defaulted to the boot default.

**img2img**

- In img2img, if the user does NOT explicitly state a `-W` or a `-H` then the input image (if not of compatible res) will be resized as per its aspect ratio to the closest compatible resolution.
- If the user sets only `-W`, then the image is resized using the set W as the reference and the height being driven by the input image.
- If the user sets only `-H`, then the image is resized using the set H as the reference and the width is driven by the input image.
- If the user sets both `-W` and `-H`, then the image will be resized to match those exact specifications and black boxes will be generated as per @lstein code.

Any code that needs to made to the how the image is scaled exactly needs to be done in `image_util.py` directly.

---

I've done a lot of testing and it seems to be working fine. But if there's a weird case that doesn't match up, then please let me know so I can fix it up.