### PR TITLE
fit the destination image size to the init image aspect ratio

### DIFF
--- a/ldm/dream/image_util.py
+++ b/ldm/dream/image_util.py
@@ -34,7 +34,7 @@ class InitImageResizer():
         # rw and rh are the resizing width and height for the image
         # they maintain the aspect ratio, but may not completelyl fill up
         # the requested destination size
-        (rw,rh) = (width,int(width/ar)) if im.width>=im.height else (int(height*ar),width)
+        (rw,rh) = (width,int(width/ar)) if im.width>=im.height else (int(height*ar),height)
 
         #round everything to multiples of 64
         width,height,rw,rh = map(

--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -179,6 +179,8 @@ class DreamServer(BaseHTTPRequestHandler):
                                             sampler_name    = sampler_name,
                                             gfpgan_strength=gfpgan_strength,
                                             upscale         = upscale,
+                                            width           = width,
+                                            height          = height,
                                             step_callback=image_progress,
                                             image_callback=image_done)
                 finally:

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -610,8 +610,19 @@ class T2I:
             image = img.convert('RGB')
         print(f'loaded input image of size {image.width}x{image.height} from {path}')
 
+        # set the larger of width,height to None in order to
+        # automagically retain aspect ratio without letterboxing
+        # This will also ensure that the image does not exceed the
+        # height x width requested by caller.
+        if image.width >= image.height:
+            height = None
+            msg    = '-W'
+        else:
+            width  = None
+            msg    = '-H'
+        
         image = InitImageResizer(image).resize(width,height)
-        print(f'resized input image to size {image.width}x{image.height}')
+        print(f'resized input image to size {image.width}x{image.height} (use {msg} to adjust)')
 
         image = np.array(image).astype(np.float32) / 255.0
         image = image[None].transpose(0, 3, 1, 2)

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -110,6 +110,8 @@ def main_loop(t2i, outdir, prompt_as_dir, parser, infile):
         name_max = 255
 
     while not done:
+
+        # TODO: move the command parsing routines into a class
         try:
             command = get_next_command(infile)
         except EOFError:
@@ -164,6 +166,7 @@ def main_loop(t2i, outdir, prompt_as_dir, parser, infile):
         if len(opt.prompt) == 0:
             print('Try again with a prompt!')
             continue
+
         if opt.seed is not None and opt.seed < 0:   # retrieve previous value!
             try:
                 opt.seed = last_seeds[opt.seed]
@@ -273,7 +276,6 @@ def write_log_message(prompt, results, log_path):
 
     with open(log_path, 'a', encoding='utf-8') as file:
         file.writelines(log_lines)
-
 
 SAMPLER_CHOICES=[
     'ddim',


### PR DESCRIPTION
Users request that the aspect ratio of the init image should constrain the dimensions of the generated image, rather than the other way around. This implements this request in a way that does not increase the overall area (and VRAM requirements) of the generated image.

In addition, there was a bug in how the destination image's dimensions were calculated, and this fixes that.