### PR TITLE
set PYTORCH_ENABLE_MPS_FALLBACK in mac environment

### DIFF
--- a/environment-mac.yaml
+++ b/environment-mac.yaml
@@ -30,3 +30,5 @@ dependencies:
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
     - -e .
+variables:
+  PYTORCH_ENABLE_MPS_FALLBACK: 1


### PR DESCRIPTION
- this enables cpu fallback for op not yet implemented for m1 gpu

Without this set, this error message is encountered:

```
NotImplementedError: The operator 'aten::_index_put_impl_' is not current implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
```