### PR TITLE
fix progress bar in webui when using strength parameter

### DIFF
--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -61,8 +61,8 @@ async function generateSubmit(form) {
     let formData = Object.fromEntries(new FormData(form));
     formData.initimg = formData.initimg.name !== '' ? await toBase64(formData.initimg) : null;
 
-    let strength = 0.75; // TODO let this be specified in the UI
-    let totalSteps = formData.initimg ? Math.floor(.75 * formData.steps) : formData.steps;
+    let strength = formData.strength;
+    let totalSteps = formData.initimg ? Math.floor(strength * formData.steps) : formData.steps;
 
     let progressSectionEle = document.querySelector('#progress-section');
     progressSectionEle.style.display = 'initial';


### PR DESCRIPTION
Followup to https://github.com/lstein/stable-diffusion/pull/239.

The total number of steps in img2img mode is controlled by the strength parameter, so this line needs to take that into account.