### PR TITLE
continue to display in-progress image until the post-processing is done

### DIFF
--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -98,7 +98,6 @@ async function generateSubmit(form) {
                     appendOutput(data.url, data.seed, data.config);
                     progressEle.setAttribute('value', 0);
                     progressEle.setAttribute('max', totalSteps);
-                    progressImageEle.src = BLANK_IMAGE_URL;
                 } else if (data.event === 'upscaling-started') {
                     document.getElementById("processing_cnt").textContent=data.processed_file_cnt;
                     document.getElementById("scaling-inprocess-message").style.display = "block";


### PR DESCRIPTION
This small tweak provides better esthetics in the period between display of the last in-progress image and end of post-processing with GFPGAN and ERSGAN.