### PR TITLE
changes to get dream.py working on M1

### DIFF
--- a/environment-mac.yaml
+++ b/environment-mac.yaml
@@ -28,7 +28,7 @@ dependencies:
     - kornia==0.6.0
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
-    - -e git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
+    - -e git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion
     - -e .
 variables:
   PYTORCH_ENABLE_MPS_FALLBACK: 1

--- a/ldm/dream/devices.py
+++ b/ldm/dream/devices.py
@@ -8,4 +8,10 @@ def choose_torch_device() -> str:
         return 'mps'
     return 'cpu'
 
-    
+def choose_autocast_device(device) -> str:
+    '''Returns an autocast compatible device from a torch device'''
+    device_type = device.type # this returns 'mps' on M1
+    # autocast only supports cuda or cpu
+    if device_type != 'cuda' or device_type != 'cpu':
+        return 'cpu'
+    return device_type

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -27,7 +27,7 @@ from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.plms import PLMSSampler
 from ldm.models.diffusion.ksampler import KSampler
 from ldm.dream.pngwriter import PngWriter
-from ldm.dream.devices import choose_torch_device
+from ldm.dream.devices import choose_autocast_device, choose_torch_device
 
 """Simplified text to image API for stable diffusion/latent diffusion
 
@@ -315,9 +315,7 @@ class T2I:
                     callback=step_callback,
                 )
 
-            device_type = self.device.type # this returns 'mps' on M1
-            if device_type != 'cuda' or device_type != 'cpu':
-                device_type = 'cpu'
+            device_type = choose_autocast_device(self.device)
             with scope(device_type), self.model.ema_scope():
                 for n in trange(iterations, desc='Generating'):
                     seed_everything(seed)

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -544,12 +544,11 @@ class T2I:
                 self.model = model.to(self.device)
                 # model.to doesn't change the cond_stage_model.device used to move the tokenizer output, so set it here
                 self.model.cond_stage_model.device = self.device
-            except AttributeError:
+            except AttributeError as e:
                 import traceback
-                print(
-                    'Error loading model. Only the CUDA backend is supported', file=sys.stderr)
+                print(f'Error loading model. {str(e)}', file=sys.stderr)
                 print(traceback.format_exc(), file=sys.stderr)
-                raise SystemExit
+                raise SystemExit from e
 
             self._set_sampler()
 

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -9,6 +9,7 @@ import sys
 import copy
 import warnings
 import time
+from ldm.dream.devices import choose_torch_device
 import ldm.dream.readline
 from ldm.dream.pngwriter import PngWriter, PromptFormatter
 from ldm.dream.server import DreamServer, ThreadingDreamServer
@@ -347,6 +348,8 @@ def create_argv_parser():
         dest='full_precision',
         action='store_true',
         help='Use slower full precision math for calculations',
+        # MPS only functions with full precision, see https://github.com/lstein/stable-diffusion/issues/237
+        default=choose_torch_device() == 'mps',
     )
     parser.add_argument(
         '-g',


### PR DESCRIPTION
- use MPS specific fork of k_diffusion
- move all device init logic to T2I.__init__
- handle m1 specific edge case with autocast device type
- check torch.cuda.is_available before using cuda

~Besides these changes, there is still an open question about what to do will the requirement to use `--full_precision` for M1. See discussion here for details: https://github.com/lstein/stable-diffusion/issues/237~ This is now addressed in the second commit.