### PR TITLE
Switch to regular pytorch channel and restore Python 3.10 for Macs.

### DIFF
--- a/README-Mac-MPS.md
+++ b/README-Mac-MPS.md
@@ -320,3 +320,20 @@ something that depends on it-- Rosetta can translate some Intel instructions but
 not the specialized ones here. To avoid this, make sure to use the environment
 variable `CONDA_SUBDIR=osx-arm64`, which restricts the Conda environment to only
 use ARM packages, and use `nomkl` as described above.
+
+### input types 'tensor<2x1280xf32>' and 'tensor<*xf16>' are not broadcast compatible
+
+May appear when just starting to generate, e.g.:
+
+```
+dream> clouds
+Generating:   0%|                                                              | 0/1 [00:00<?, ?it/s]/Users/[...]/dev/stable-diffusion/ldm/modules/embedding_manager.py:152: UserWarning: The operator 'aten::nonzero' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (Triggered internally at /Users/runner/work/_temp/anaconda/conda-bld/pytorch_1662016319283/work/aten/src/ATen/mps/MPSFallback.mm:11.)
+  placeholder_idx = torch.where(
+                                                                                                    loc("mps_add"("(mpsFileLoc): /AppleInternal/Library/BuildRoots/20d6c351-ee94-11ec-bcaf-7247572f23b4/Library/Caches/com.apple.xbs/Sources/MetalPerformanceShadersGraph/mpsgraph/MetalPerformanceShadersGraph/Core/Files/MPSGraphUtilities.mm":219:0)): error: input types 'tensor<2x1280xf32>' and 'tensor<*xf16>' are not broadcast compatible
+LLVM ERROR: Failed to infer result type(s).
+Abort trap: 6
+/Users/[...]/opt/anaconda3/envs/ldm/lib/python3.9/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
+  warnings.warn('resource_tracker: There appear to be %d '
+  ```
+
+Macs do not support autocast/mixed-precision. Supply `--full_precision` to use float32 everywhere.

--- a/environment-mac.yaml
+++ b/environment-mac.yaml
@@ -1,33 +1,29 @@
 name: ldm
 channels:
-  - pytorch-nightly
+  - pytorch
   - conda-forge
 dependencies:
-  - python==3.9.13
+  - python==3.10.5
   - pip==22.2.2
  
-  # pytorch-nightly, left unpinned
+  # pytorch left unpinned
   - pytorch
-  - torchmetrics
   - torchvision
 
   # I suggest to keep the other deps sorted for convenience.
-  # If you wish to upgrade to 3.10, try to run this:
+  # To determine what the latest versions should be, run:
   #
   # ```shell
-  # CONDA_CMD=conda
-  # sed -E 's/python==3.9.13/python==3.10.5/;s/ldm/ldm-3.10/;21,99s/- ([^=]+)==.+/- \1/' environment-mac.yaml > /tmp/environment-mac-updated.yml
-  # CONDA_SUBDIR=osx-arm64 $CONDA_CMD env create -f /tmp/environment-mac-updated.yml && $CONDA_CMD list -n ldm-3.10 | awk ' {print "  - " $1 "==" $2;} '
+  # sed -E 's/ldm/ldm-updated/;20,99s/- ([^=]+)==.+/- \1/' environment-mac.yaml > environment-mac-updated.yml
+  # CONDA_SUBDIR=osx-arm64 conda env create -f environment-mac-updated.yml && conda list -n ldm-updated | awk ' {print "  - " $1 "==" $2;} '
   # ```
-  #
-  # Unfortunately, as of 2022-08-31, this fails at the pip stage.
   - albumentations==1.2.1
   - coloredlogs==15.0.1
   - einops==0.4.1
   - grpcio==1.46.4
-  - humanfriendly
-  - imageio-ffmpeg==0.4.7
+  - humanfriendly==10.0
   - imageio==2.21.2
+  - imageio-ffmpeg==0.4.7
   - imgaug==0.4.0
   - kornia==0.6.7
   - mpmath==1.2.1
@@ -43,13 +39,11 @@ dependencies:
   - streamlit==1.12.2
   - sympy==1.10.1
   - tensorboard==2.9.0
-  - transformers==4.21.2
+  - torchmetrics==0.9.3
   - pip:
-    - invisible-watermark
     - test-tube
-    - tokenizers
+    - transformers
     - torch-fidelity
-    - -e git+https://github.com/huggingface/diffusers.git@v0.2.4#egg=diffusers
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion

--- a/environment-mac.yaml
+++ b/environment-mac.yaml
@@ -41,9 +41,9 @@ dependencies:
   - tensorboard==2.9.0
   - torchmetrics==0.9.3
   - pip:
-    - test-tube
-    - transformers
-    - torch-fidelity
+    - test-tube==0.7.5
+    - transformers==4.21.2
+    - torch-fidelity==0.3.0
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k_diffusion


### PR DESCRIPTION
Although pytorch-nightly should in theory be faster, it is currently
causing increased memory usage and slower iterations:

https://github.com/lstein/stable-diffusion/pull/283#issuecomment-1234784885

This changes the environment-mac.yaml file back to the regular pytorch
channel and moves the `transformers` dep into pip for now (since it
cannot be satisfied until tokenizers>=0.11 is built for Python 3.10).

I tried to update the tokenizers package (https://github.com/conda-forge/tokenizers-feedstock/pull/51)
but ran into some build failures; I'll try to fix those and then move `transformers`
into the conda-forge deps.