### PR TITLE
chore: update requirements.txt to run on m1 w/pip

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+**Describe your environment**
+- GPU: [cuda/amd/mps/cpu]
+- VRAM: [if known]
+- CPU arch: [x86/arm]
+- OS: [Linux/Windows/macOS]
+- Python: [Anaconda/miniconda/miniforge/pyenv/other (explain)]
+- Branch: [if `git status` says anything other than "On branch main" paste it here]
+- Commit: [run `git show` and paste the line that starts with "Merge" here]
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -22,17 +31,6 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -730,8 +730,8 @@ be fast because all the dependencies are already loaded.
 Anyone who wishes to contribute to this project, whether
 documentation, features, bug fixes, code cleanup, testing, or code
 reviews, is very much encouraged to do so. If you are unfamiliar with
-how to contribute to GitHub projects, here is a (Getting Started
-Guide)[https://opensource.com/article/19/7/create-pull-request-github].
+how to contribute to GitHub projects, here is a [Getting Started
+Guide](https://opensource.com/article/19/7/create-pull-request-github).
 
 A full set of contribution guidelines, along with templates, are in
 progress, but for now the most important thing is to **make your pull

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ text-to-image generator. This fork supports:
 1. An interactive command-line interface that accepts the same prompt
    and switches as the Discord bot.
 
-2. Support for img2img in which you provide a seed image to build on
-   top of.
-
-3. A basic Web interface that allows you to run a local web server for
+2. A basic Web interface that allows you to run a local web server for
    generating images in your browser.
-4. A notebook for running the code on Google Colab.
+
+3. A notebook for running the code on Google Colab.
+
+4. Support for img2img in which you provide a seed image to guide the
+      image creation. (inpainting & masking coming soon)
 
 5. Upscaling and face fixing using the optional ESRGAN and GFPGAN
    packages.
@@ -44,7 +45,8 @@ improvements and bug fixes.
 2. [Changelog](#latest)
 3. [Installation](#installation)
 4. [Troubleshooting](#troubleshooting)
-5. [Support](#support)
+5. [Contributing](#contributing)
+6. [Support](#support)
 
 # Features
 
@@ -394,10 +396,10 @@ repository and associated paper for details and limitations.
   - Supports a Google Colab notebook for a standalone server running on Google hardware [Arturo Mendivil](https://github.com/artmen1516)
   - WebUI supports GFPGAN/ESRGAN facial reconstruction and upscaling [Kevin Gibbons](https://github.com/bakkot)
   - WebUI supports incremental display of in-progress images during generation [Kevin Gibbons](https://github.com/bakkot)
-  - Output directory can be specified on the dream> command line.
-  - The grid was displaying duplicated images when not enough images to fill the final row [Muhammad Usama](https://github.com/SMUsamaShah)
   - Can specify --grid on dream.py command line as the default.
   - Miscellaneous internal bug and stability fixes.
+  - Works on M1 Apple hardware.
+  - Multiple bug fixes.
 
 For older changelogs, please visit **[CHANGELOGS](CHANGELOG.md)**.
 
@@ -723,6 +725,20 @@ of branch>
 You will need to go through the install procedure again, but it should
 be fast because all the dependencies are already loaded.
 
+# Contributing
+
+Anyone who wishes to contribute to this project, whether
+documentation, features, bug fixes, code cleanup, testing, or code
+reviews, is very much encouraged to do so. If you are unfamiliar with
+how to contribute to GitHub projects, here is a (Getting Started
+Guide)[https://opensource.com/article/19/7/create-pull-request-github].
+
+A full set of contribution guidelines, along with templates, are in
+progress, but for now the most important thing is to **make your pull
+request against the "development" branch**, and not against
+"main". This will help keep public breakage to a minimum and will
+allow you to propose more radical changes.
+
 # Support
 
 For support,
@@ -735,8 +751,12 @@ _Contributions by:_
 [Peter Kowalczyk](https://github.com/slix), [Henry Harrison](https://github.com/hwharrison),
 [xraxra](https://github.com/xraxra), [bmaltais](https://github.com/bmaltais), [Sean McLellan](https://github.com/Oceanswave),
 [nicolai256](https://github.com/nicolai256), [Benjamin Warner](https://github.com/warner-benjamin),
-[tildebyte](https://github.com/tildebyte),[yunsaki](https://github.com/yunsaki)
-and [Tesseract Cat](https://github.com/TesseractCat)
+[tildebyte](https://github.com/tildebyte),[yunsaki](https://github.com/yunsaki), [James Reynolds][https://github.com/magnusviri],
+[Tesseract Cat](https://github.com/TesseractCat), and many more!
+
+(If you have contributed and don't see your name on the list of
+contributors, please let lstein know about the omission, or make a
+pull request)
 
 Original portions of the software are Copyright (c) 2020 Lincoln D. Stein (https://github.com/lstein)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,13 @@ huggingface-hub==0.8.1
 imageio==2.9.0
 imageio-ffmpeg==0.4.2
 kornia==0.6.0
-numpy==1.19.2
+numpy==1.23.1
+--pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 omegaconf==2.1.1
-opencv-python==4.1.2.30
+opencv-python==4.6.0.66
 pillow==9.2.0
 pudb==2019.2
-torch==1.11.0
+torch==1.12.1
 torchvision==0.12.0
 pytorch-lightning==1.4.2
 streamlit==1.12.0
@@ -19,4 +20,4 @@ torchmetrics==0.6.0
 transformers==4.19.2
 -e git+https://github.com/openai/CLIP.git@main#egg=clip
 -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
--e git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
+-e git+https://github.com/Birch-san/k-diffusion.git@mps#egg=k-diffusion


### PR DESCRIPTION
this is similar to #334, which updates numpy and opencv-python similarly. however, there are several additional and necessary changes: updating torch to 1.12 (which adds support for mps, the whole point of this), and updating the k-diffusion repo to point to the mps fork