### PR TITLE
Add seamless tiling mode and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ You may also pass a -v<count> option to generate count variants on the original 
 passing the first generated image back into img2img the requested number of times. It generates interesting
 variants.
 
+## Seamless Tiling
+
+The seamless tiling mode causes generated images to be seamlessly tile with itself. To use it, add the --seamless option when starting the script which will result in all generated images to tile, or for each dream> prompt as shown here:
+```
+dream> "pond garden with lotus by claude monet" --seamless -s100 -n4
+```
+
 ## GFPGAN and Real-ESRGAN Support
 
 The script also provides the ability to do face restoration and

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ variants.
 
 ## Seamless Tiling
 
-The seamless tiling mode causes generated images to be seamlessly tile with itself. To use it, add the --seamless option when starting the script which will result in all generated images to tile, or for each dream> prompt as shown here:
+The seamless tiling mode causes generated images to seamlessly tile with itself. To use it, add the --seamless option when starting the script which will result in all generated images to tile, or for each dream> prompt as shown here:
 ```
 dream> "pond garden with lotus by claude monet" --seamless -s100 -n4
 ```

--- a/ldm/dream/pngwriter.py
+++ b/ldm/dream/pngwriter.py
@@ -59,6 +59,8 @@ class PromptFormatter:
         switches.append(f'-H{opt.height       or t2i.height}')
         switches.append(f'-C{opt.cfg_scale    or t2i.cfg_scale}')
         switches.append(f'-A{opt.sampler_name or t2i.sampler_name}')
+        if opt.seamless or t2i.seamless:
+            switches.append(f'--seamless')
         if opt.init_img:
             switches.append(f'-I{opt.init_img}')
         if opt.fit:

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -14,6 +14,7 @@ from PIL import Image
 from tqdm import tqdm, trange
 from itertools import islice
 from einops import rearrange, repeat
+from torch import nn
 from torchvision.utils import make_grid
 from pytorch_lightning import seed_everything
 from torch import autocast
@@ -109,6 +110,7 @@ class T2I:
         downsampling_factor
         precision
         strength
+        seamless
         embedding_path
 
     The vast majority of these arguments default to reasonable values.
@@ -132,6 +134,7 @@ class T2I:
             precision='autocast',
             full_precision=False,
             strength=0.75,  # default in scripts/img2img.py
+            seamless=False,
             embedding_path=None,
             device_type = 'cuda',
             # just to keep track of this parameter when regenerating prompt
@@ -153,6 +156,7 @@ class T2I:
         self.precision                = precision
         self.full_precision           = full_precision
         self.strength                 = strength
+        self.seamless                 = seamless
         self.embedding_path           = embedding_path
         self.device_type              = device_type
         self.model                    = None     # empty for now
@@ -217,6 +221,7 @@ class T2I:
             step_callback  =    None,
             width          =    None,
             height         =    None,
+            seamless       =    False,
             # these are specific to img2img
             init_img       =    None,
             fit            =    False,
@@ -238,6 +243,7 @@ class T2I:
            width                           // width of image, in multiples of 64 (512)
            height                          // height of image, in multiples of 64 (512)
            cfg_scale                       // how strongly the prompt influences the image (7.5) (must be >1)
+           seamless                        // whether the generated image should tile
            init_img                        // path to an initial image - its dimensions override width and height
            strength                        // strength for noising/unnoising init_img. 0.0 preserves image exactly, 1.0 replaces it completely
            gfpgan_strength                 // strength for GFPGAN. 0.0 preserves image exactly, 1.0 replaces it completely
@@ -265,6 +271,7 @@ class T2I:
         seed                  = seed       or self.seed
         width                 = width      or self.width
         height                = height     or self.height
+        seamless              = seamless   or self.seamless
         cfg_scale             = cfg_scale  or self.cfg_scale
         ddim_eta              = ddim_eta   or self.ddim_eta
         iterations            = iterations or self.iterations
@@ -274,6 +281,10 @@ class T2I:
         model = (
             self.load_model()
         )  # will instantiate the model or return it from cache
+        for m in model.modules():
+            if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
+                m.padding_mode = 'circular' if seamless else m._orig_padding_mode
+        
         assert cfg_scale > 1.0, 'CFG_Scale (-C) must be >1.0'
         assert (
             0.0 <= strength <= 1.0
@@ -561,6 +572,10 @@ class T2I:
                 raise SystemExit from e
 
             self._set_sampler()
+
+            for m in self.model.modules():
+                if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
+                    m._orig_padding_mode = m.padding_mode
 
         return self.model
 

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -87,20 +87,15 @@ def main():
             print(f'{e}. Aborting.')
             sys.exit(-1)
 
+    if opt.seamless:
+        print(">> changed to seamless tiling mode")
+
     # preload the model
     tic = time.time()
     t2i.load_model()
     print(
         f'>> model loaded in', '%4.2fs' % (time.time() - tic)
     )
-
-    for m in t2i.model.modules():
-        if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
-            m._orig_padding_mode = m.padding_mode
-            if opt.seamless:
-                m.padding_mode = 'circular'
-    if opt.seamless:
-        print(">> changed to seamless tiling mode")
 
     if not infile:
         print(


### PR DESCRIPTION
Added capability for stable-diffusion to create seamless tiling image in `ldm/simplet2i.py`
Added --seamless command to both cmd argument and dream argument in `scripts/dream.py`

Examples:
![000029 938924409](https://user-images.githubusercontent.com/34859963/188258487-14146b89-48cf-4178-9cea-1255c4f805ef.png)
![seed_674019_00003](https://user-images.githubusercontent.com/34859963/188258604-ef04dbf9-4dae-4018-920d-8457d0d7214f.png)
![seed_735063_00000](https://user-images.githubusercontent.com/34859963/188258508-61313a07-48a0-454d-b73c-c272f1cc412c.png)
