### PR TITLE
fix save_original flag saving to the same filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,10 +427,12 @@ There are separate installation walkthroughs for [Linux](#linux), [Windows](#win
 - Python (version 3.8.5 recommended; higher may work)
 - git
 
-2. Install the Python Anaconda environment manager using pip3.
+2. Install the Python Anaconda environment manager.
 
 ```
-~$ pip3 install anaconda
+~$  wget https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh
+~$  chmod +x Anaconda3-2022.05-Linux-x86_64.sh 
+~$  ./Anaconda3-2022.05-Linux-x86_64.sh  
 ```
 
 After installing anaconda, you should log out of your system and log back in. If the installation

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -412,10 +412,7 @@ class T2I:
                                 f'>> Error running RealESRGAN - Your image was not upscaled.\n{e}'
                             )
                         if image_callback is not None:
-                            if save_original:
-                                image_callback(image, seed)
-                            else:
-                                image_callback(image, seed, upscaled=True)
+                            image_callback(image, seed, upscaled=True)
                         else:  # no callback passed, so we simply replace old image with rescaled one
                             result[0] = image
 


### PR DESCRIPTION
Before this, the `--save_orig` flag was not working. The upscaled/GFPGAN would overwrite the original output image.