### PR TITLE
Revert "Add CORS headers to dream server to ease integration with third-party web interfaces"

### DIFF
--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -16,8 +16,6 @@ class DreamServer(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/":
             self.send_response(200)
-            self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
             self.send_header("Content-type", "text/html")
             self.end_headers()
             with open("./static/dream_web/index.html", "rb") as content:
@@ -35,8 +33,6 @@ class DreamServer(BaseHTTPRequestHandler):
         elif self.path == "/cancel":
             self.canceled.set()
             self.send_response(200)
-            self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
             self.send_header("Content-type", "application/json")
             self.end_headers()
             self.wfile.write(bytes('{}', 'utf8'))
@@ -59,8 +55,6 @@ class DreamServer(BaseHTTPRequestHandler):
 
     def do_POST(self):
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
         self.send_header("Content-type", "application/json")
         self.end_headers()
 
@@ -205,11 +199,6 @@ class DreamServer(BaseHTTPRequestHandler):
             print(f"Canceled.")
             return
 
-    def do_OPTIONS(self):
-        self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
-        self.end_headers()
 
 class ThreadingDreamServer(ThreadingHTTPServer):
     def __init__(self, server_address):


### PR DESCRIPTION
This reverts commit 91e826e5f425333674d1e3bec1fa1ac63cfb382d.

The cross-origin policy is an important security feature which #363 disabled entirely. Adding these headers means that any website you visit can talk to the web server, including submitting requests. That's certainly not something I'd expect to happen by default, and and our codebase hasn't really been built with the level of attention to security necessary for that to be at all safe (cf https://github.com/lstein/stable-diffusion/pull/133).

Perhaps this functionality can be added back at a later time as an opt-in under a flag like `--dangerously-disable-cors`, or where the flag allows you to specify a specific origin rather than allowing literally anything, but best to start by reverting this and then re-doing it in a safe way.

cc @SebastianAigner