### PR TITLE
Web UI: Style and structure tweaks

### DIFF
--- a/static/dream_web/index.css
+++ b/static/dream_web/index.css
@@ -1,11 +1,14 @@
 * {
     font-family: 'Arial';
+    font-size: 100%;
 }
-#header {
-    text-decoration: dotted underline;
+body {
+    font-size: 1em;
 }
-#search {
-    margin-top: 20vh;
+textarea {
+    font-size: 0.95em;
+}
+header, form, #progress-section {
     margin-left: auto;
     margin-right: auto;
     max-width: 1024px;
@@ -13,46 +16,78 @@
 }
 fieldset {
     border: none;
+    line-height: 2.2em;
+}
+select, input {
+    margin-right: 10px;
+    padding: 2px;
+}
+input[type=submit] {
+    background-color: #666;
+    color: white;
+}
+input[type=checkbox] {
+    margin-right: 0px;
+    width: 20px;
+    height: 20px;
+    vertical-align: middle;
+}
+input#seed {
+    margin-right: 0px;
 }
 div {
     padding: 10px 10px 10px 10px;
 }
-#fieldset-search {
+header {
+    margin-bottom: 16px;
+}
+header h1 {
+    margin-bottom: 0;
+    font-size: 2em;
+}
+#search-box {
     display: flex;
 }
-#scaling-inprocess-message{
+#scaling-inprocess-message {
     font-weight: bold;
     font-style: italic;
     display: none;
 }
 #prompt {
     flex-grow: 1;
-
-    border-radius: 20px 0px 0px 20px;
     padding: 5px 10px 5px 10px;
-    border: 1px solid black;
-    border-right: none;
+    border: 1px solid #999;
     outline: none;
 }
 #submit {
-    border-radius: 0px 20px 20px 0px;
     padding: 5px 10px 5px 10px;
-    border: 1px solid black;
+    border: 1px solid #999;
 }
 #reset-all {
+    margin-top: 12px;
+    font-size: 0.8em;
     background-color: pink;
+    border: 1px solid #999;
+    border-radius: 4px;
 }
 #results {
     text-align: center;
-//    max-width: 1024px;
     margin: auto;
     padding-top: 10px;
 }
-#results img {
+#results figure {
+    display: inline-block;
+    margin: 10px;
+}
+#results figcaption {
+    font-size: 0.8em;
+    padding: 3px;
+    color: #888;
     cursor: pointer;
+}
+#results img {
     height: 30vh;
     border-radius: 5px;
-    margin: 10px;
 }
 #fieldset-config {
     line-height:2em;
@@ -63,8 +98,15 @@ input[type="number"] {
 #seed {
     width: 150px;
 }
-hr {
-//    width: 200px;
+button#reset-seed {
+    font-size: 1.7em;
+    background: #efefef;
+    border: 1px solid #999;
+    border-radius: 4px;
+    line-height: 0.8;
+    margin: 0 10px 0 0;
+    padding: 0 5px 3px;
+    vertical-align: middle;
 }
 label {
     white-space: nowrap;
@@ -92,6 +134,4 @@ label {
 #progress-section {
     background-color: #F5F5F5;
 }
-#about {
-    background-color: #DCDCDC;
-}
+

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -10,73 +10,79 @@
     <script src="static/dream_web/index.js"></script>
   </head>
   <body>
-    <div id="search">
-      <h2 id="header">Stable Diffusion Dream Server</h2>
+    <header>
+      <h1>Stable Diffusion Dream Server</h1>
+      <div id="about">
+        For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a>
+      </div>
+    </header>
 
+    <main>
       <form id="generate-form" method="post" action="#">
-	<div id="txt2img">
-          <fieldset id="fieldset-search">
-            <input type="text" id="prompt" name="prompt">
+	      <fieldset id="txt2img">
+          <div id="search-box">
+            <textarea rows="3" id="prompt" name="prompt"></textarea>
             <input type="submit" id="submit" value="Generate">
-          </fieldset>
-          <fieldset id="fieldset-config">
-            <label for="iterations">Images to generate:</label>
-            <input value="1" type="number" id="iterations" name="iterations" size="4">
-            <label for="steps">Steps:</label>
-            <input value="50" type="number" id="steps" name="steps">
-            <label for="cfgscale">Cfg Scale:</label>
-            <input value="7.5" type="number" id="cfgscale" name="cfgscale" step="any">
-            <label for="sampler">Sampler:</label>
-            <select id="sampler" name="sampler" value="k_lms">
-              <option value="ddim">DDIM</option>
-              <option value="plms">PLMS</option>
-              <option value="k_lms" selected>KLMS</option>
-              <option value="k_dpm_2">KDPM_2</option>
-              <option value="k_dpm_2_a">KDPM_2A</option>
-              <option value="k_euler">KEULER</option>
-	      <option value="k_euler_a">KEULER_A</option>
-              <option value="k_heun">KHEUN</option>
-            </select>
-            <br>
-            <label title="Set to multiple of 64" for="width">Width:</label>
-            <select id="width" name="width" value="512">
-              <option value="64">64</option> <option value="128">128</option>
-              <option value="192">192</option> <option value="256">256</option>
-              <option value="320">320</option> <option value="384">384</option>
-              <option value="448">448</option> <option value="512" selected>512</option>
-              <option value="576">576</option> <option value="640">640</option>
-              <option value="704">704</option> <option value="768">768</option>
-              <option value="832">832</option> <option value="896">896</option>
-              <option value="960">960</option> <option value="1024">1024</option>
-            </select>
-            <label title="Set to multiple of 64" for="height">Height:</label>
-            <select id="height" name="height" value="512">
-              <option value="64">64</option> <option value="128">128</option>
-              <option value="192">192</option> <option value="256">256</option>
-              <option value="320">320</option> <option value="384">384</option>
-              <option value="448">448</option> <option value="512" selected>512</option>
-              <option value="576">576</option> <option value="640">640</option>
-              <option value="704">704</option> <option value="768">768</option>
-              <option value="832">832</option> <option value="896">896</option>
-              <option value="960">960</option> <option value="1024">1024</option>
-            </select>
-            <label title="Set to -1 for random seed" for="seed">Seed:</label>
-            <input value="-1" type="number" id="seed" name="seed">
-            <button type="button" id="reset-seed">&olarr;</button>
-            <input type="checkbox" name="progress_images" id="progress_images">
-	    <label for="progress_images">Display in-progress images (slows down generation):</label>
-	    <button type="button" id="reset-all">Reset to Defaults</button>
-	</div>
-	<div id="img2img">
+          </div>
+          <label for="iterations">Images to generate:</label>
+          <input value="1" type="number" id="iterations" name="iterations" size="4">
+          <label for="steps">Steps:</label>
+          <input value="50" type="number" id="steps" name="steps">
+          <label for="cfgscale">Cfg Scale:</label>
+          <input value="7.5" type="number" id="cfgscale" name="cfgscale" step="any">
+          <label for="sampler">Sampler:</label>
+          <select id="sampler" name="sampler" value="k_lms">
+            <option value="ddim">DDIM</option>
+            <option value="plms">PLMS</option>
+            <option value="k_lms" selected>KLMS</option>
+            <option value="k_dpm_2">KDPM_2</option>
+            <option value="k_dpm_2_a">KDPM_2A</option>
+            <option value="k_euler">KEULER</option>
+            <option value="k_euler_a">KEULER_A</option>
+            <option value="k_heun">KHEUN</option>
+          </select>
+
+          <br>
+          <label title="Set to multiple of 64" for="width">Width:</label>
+          <select id="width" name="width" value="512">
+            <option value="64">64</option> <option value="128">128</option>
+            <option value="192">192</option> <option value="256">256</option>
+            <option value="320">320</option> <option value="384">384</option>
+            <option value="448">448</option> <option value="512" selected>512</option>
+            <option value="576">576</option> <option value="640">640</option>
+            <option value="704">704</option> <option value="768">768</option>
+            <option value="832">832</option> <option value="896">896</option>
+            <option value="960">960</option> <option value="1024">1024</option>
+          </select>
+          <label title="Set to multiple of 64" for="height">Height:</label>
+          <select id="height" name="height" value="512">
+            <option value="64">64</option> <option value="128">128</option>
+            <option value="192">192</option> <option value="256">256</option>
+            <option value="320">320</option> <option value="384">384</option>
+            <option value="448">448</option> <option value="512" selected>512</option>
+            <option value="576">576</option> <option value="640">640</option>
+            <option value="704">704</option> <option value="768">768</option>
+            <option value="832">832</option> <option value="896">896</option>
+            <option value="960">960</option> <option value="1024">1024</option>
+          </select>
+
+          <label title="Set to -1 for random seed" for="seed">Seed:</label>
+          <input value="-1" type="number" id="seed" name="seed">
+          <button type="button" id="reset-seed">&olarr;</button>
+          <input type="checkbox" name="progress_images" id="progress_images">
+          <label for="progress_images">Display in-progress images (slows down generation):</label>
+          <button type="button" id="reset-all">Reset to Defaults</button>
+        </fieldset>
+	      <fieldset id="img2img">
           <label title="Upload an image to use img2img" for="initimg">Initial image:</label>
           <input type="file" id="initimg" name="initimg" accept=".jpg, .jpeg, .png">
-	  <br>
+	        <br>
           <label for="strength">Img2Img Strength:</label>
           <input value="0.75" type="number" id="strength" name="strength" step="0.01" min="0" max="1">
           <input type="checkbox" id="fit" name="fit" checked>
           <label title="Rescale image to fit within requested width and height" for="fit">Fit to width/height:</label>
-	</div>
-        <div id="gfpgan">
+	      </fieldset>
+        <fieldset id="gfpgan">
           <label title="Strength of the gfpgan (face fixing) algorithm." for="gfpgan_strength">GPFGAN Strength (0 to disable):</label>
           <input value="0.8" min="0" max="1" type="number" id="gfpgan_strength" name="gfpgan_strength" step="0.05">
           <label title="Upscaling to perform using ESRGAN." for="upscale_level">Upscaling Level</label>
@@ -87,25 +93,33 @@
           </select>
           <label title="Strength of the esrgan (upscaling) algorithm." for="upscale_strength">Upscale Strength:</label>
           <input value="0.75" min="0" max="1" type="number" id="upscale_strength" name="upscale_strength" step="0.05">
-        </div>
         </fieldset>
       </form>
-      <div id="about">For news and support for this web service, visit our <a href="http://github.com/lstein/stable-diffusion">GitHub site</a></div>
       <br>
-      <div id="progress-section">
-        <progress id="progress-bar" value="0" max="1"></progress>
-        <span id="cancel-button" title="Cancel">&#10006;</span>
-        <br>
-        <img id="progress-image" src='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>'></img>
-        <div id="scaling-inprocess-message">
-          <i><span>Postprocessing...</span><span id="processing_cnt">1/3</span></i>
+      <section id="progress-section">
+        <div id="progress-container">
+          <progress id="progress-bar" value="0" max="1"></progress>
+          <span id="cancel-button" title="Cancel">&#10006;</span>
+          <br>
+          <img id="progress-image" src='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>'></img>
+          <div id="scaling-inprocess-message">
+            <i><span>Postprocessing...</span><span id="processing_cnt">1/3</span></i>
+          </div>
+        </div>
+      </section>
+
+      <div id="results">
+        <div id="no-results-message">
+          <i><p>No results...</p></i>
         </div>
       </div>
-    </div>
-    <div id="results">
-      <div id="no-results-message">
-        <i><p>No results...</p></i>
-      </div>
-    </div>
+    </main>
+    <figure style="display:none">
+      <a href="./outputs/img-samples/000060.419380511.png" target="_blank">
+        <img src="./outputs/img-samples/000060.419380511.png" alt="419380511 | A full portrait of a beautiful post apocalyptic winged siren, intricate, elegant, highly detailed, digital painting, artstation, concept art, smooth, sharp focus, illustration, art by Krenz Cushart and Artem Demura and alphonse mucha" title="419380511 | A full portrait of a beautiful post apocalyptic winged siren, intricate, elegant, highly detailed, digital painting, artstation, concept art, smooth, sharp focus, illustration, art by Krenz Cushart and Artem Demura and alphonse mucha">
+      </a>
+      <figcaption>419380511</figcaption>
+    </figure>
+
   </body>
 </html>

--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -114,12 +114,5 @@
         </div>
       </div>
     </main>
-    <figure style="display:none">
-      <a href="./outputs/img-samples/000060.419380511.png" target="_blank">
-        <img src="./outputs/img-samples/000060.419380511.png" alt="419380511 | A full portrait of a beautiful post apocalyptic winged siren, intricate, elegant, highly detailed, digital painting, artstation, concept art, smooth, sharp focus, illustration, art by Krenz Cushart and Artem Demura and alphonse mucha" title="419380511 | A full portrait of a beautiful post apocalyptic winged siren, intricate, elegant, highly detailed, digital painting, artstation, concept art, smooth, sharp focus, illustration, art by Krenz Cushart and Artem Demura and alphonse mucha">
-      </a>
-      <figcaption>419380511</figcaption>
-    </figure>
-
   </body>
 </html>

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -13,7 +13,7 @@ function appendOutput(src, seed, config) {
 
     const figureContents = `
         <a href="${src}" target="_blank">
-            <img src="${src}" alt="${altText}">
+            <img src="${src}" alt="${altText}" title="${altText}">
         </a>
         <figcaption>${seed}</figcaption>
     `;

--- a/static/dream_web/index.js
+++ b/static/dream_web/index.js
@@ -8,15 +8,21 @@ function toBase64(file) {
 }
 
 function appendOutput(src, seed, config) {
-    let outputNode = document.createElement("img");
-    outputNode.src = src;
-
+    let outputNode = document.createElement("figure");
     let altText = seed.toString() + " | " + config.prompt;
-    outputNode.alt = altText;
-    outputNode.title = altText;
+
+    const figureContents = `
+        <a href="${src}" target="_blank">
+            <img src="${src}" alt="${altText}">
+        </a>
+        <figcaption>${seed}</figcaption>
+    `;
+
+    outputNode.innerHTML = figureContents;
+    let figcaption = outputNode.querySelector('figcaption')
 
     // Reload image config
-    outputNode.addEventListener('click', () => {
+    figcaption.addEventListener('click', () => {
         let form = document.querySelector("#generate-form");
         for (const [k, v] of new FormData(form)) {
             form.querySelector(`*[name=${k}]`).value = config[k];


### PR DESCRIPTION
Primary thrust of this PR is style tweaks to make the web ui just a tad more usable:
- Larger prompt box with a larger font size
- A bit more spacing between setting inputs
- Moving the form to the top of the page
- Allowing the image results to flow across entire viewport
- A little be better HTML organization (a fieldset each for `txt2img`, `img2img`, `gfpgan`, etc)

Besides styling this PR also changes some functionality:
- Clicking an image now opens the full size version in a new window
- Added the seed number below the image; clicking the seed number loads the seed into the current form

Hope this helps, but no biggie if you don't want to merge. In any case -- thanks for you hard work, @lstein! 

Video (Chrome): https://scottymac.s3.amazonaws.com/stable-diffusion/pr-images/sd-web-ui-update.mp4

<details><summary>Screenshots:</summary>

## Chrome
![Screenshot (Chrome)](https://scottymac.s3.amazonaws.com/stable-diffusion/pr-images/sd-chrome.png)

## Firefox
![Screen Shot (Firefox)](https://scottymac.s3.amazonaws.com/stable-diffusion/pr-images/sd-firefox.png)

## Safari
![Screen Shot (Safari)](https://scottymac.s3.amazonaws.com/stable-diffusion/pr-images/sd-safari.png)

</details>

