### PR TITLE
put no_grad decorator on make_image closures

### DIFF
--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -474,6 +474,7 @@ class T2I:
 
         sampler = self.sampler
 
+        @torch.no_grad()
         def make_image(x_T):
             uc, c = self._get_uc_and_c(prompt, skip_normalize)
             shape = [
@@ -528,6 +529,7 @@ class T2I:
 
         t_enc = int(strength * steps)
 
+        @torch.no_grad()
         def make_image(x_T):
             uc, c = self._get_uc_and_c(prompt, skip_normalize)
 


### PR DESCRIPTION
Fixes https://github.com/lstein/stable-diffusion/issues/358. This fixes a regression in VRAM usage from https://github.com/lstein/stable-diffusion/pull/277 - specifically, in switching from an iterator to a closure, I did not add this decorator to the closure; it was still "in effect" for the body of an iterator but not for the body of a closure.

Sorry about that. But hey, now I know what `no_grad` does! (And also more about how decorators work in Python.)