### PR TITLE
Documentation. Update instructions with how to install alongside pyenv

### DIFF
--- a/README-Mac-MPS.md
+++ b/README-Mac-MPS.md
@@ -32,12 +32,33 @@ While that is downloading, open Terminal and run the following commands one at a
 # install brew (and Xcode command line tools):
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+#
+# Now there are two different routes to get the Python (miniconda) environment up and running:
+# 1. Alongside pyenv
+# 2. No pyenv
+#
+# If you don't know what we are talking about, choose 2.
+# 
+# NOW EITHER DO
+# 1. Installing alongside pyenv 
+
+brew install pyenv-virtualenv # you might have this from before, no problem
+pyenv install anaconda3-latest
+pyenv virtualenv anaconda3-latest lstein-stable-diffusion
+pyenv activate lstein-stable-diffusion
+
+# OR, 
+# 2. Installing standalone
 # install python 3, git, cmake, protobuf:
 brew install cmake protobuf rust
 
 # install miniconda (M1 arm64 version):
 curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o Miniconda3-latest-MacOSX-arm64.sh
 /bin/bash Miniconda3-latest-MacOSX-arm64.sh
+
+
+# EITHER WAY,
+# continue from here
 
 # clone the repo
 git clone https://github.com/lstein/stable-diffusion.git


### PR DESCRIPTION
Like probably many others, I have a lot of different virtualenvs, one for each project. Most of them are handled by `pyenv`. 
After installing according to these instructions I had issues with ´pyenv`and `miniconda` fighting over the $PATH of my system.
But then I stumbled upon this nice solution on SO: https://stackoverflow.com/a/73139031 , upon which I have based my suggested changes.

It runs perfectly on my M1 setup, with the anaconda setup as a virtual environment handled by pyenv. 

Feel free to incorporate these instructions as you see fit. 

Thanks a million for all your hard work.