### PR TITLE
Add support of RealESRGAN for Apple M1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # ignore default image save location and model symbolic link
 outputs/
 models/ldm/stable-diffusion-v1/model.ckpt
-gfpgan/
+gfpgan/*
 
 # ignore a directory which serves as a place for initial images
 inputs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore default image save location and model symbolic link
 outputs/
 models/ldm/stable-diffusion-v1/model.ckpt
+gfpgan/
 
 # ignore a directory which serves as a place for initial images
 inputs/

--- a/README-Mac-MPS.md
+++ b/README-Mac-MPS.md
@@ -64,10 +64,12 @@ REALESRGAN_GITHUB_URL="https://github.com/xinntao/Real-ESRGAN/releases/download/
 REALESRGAN_ARCHIVE="realesrgan.zip"
 REALESRGAN_PATH="realesrgan"
 
-curl $REALESRGAN_GITHUB_URL -o $REALESRGAN_ARCHIVE
+mkdir $REALESRGAN_PATH
+cd $REALESRGAN_PATH
+curl -L $REALESRGAN_GITHUB_URL -o $REALESRGAN_ARCHIVE
 unzip $REALESRGAN_ARCHIVE
 rm $REALESRGAN_ARCHIVE
-chmod u+x $REALESRGAN_PATH/realesrgan-ncnn-vulkan
+chmod u+x ./realesrgan-ncnn-vulkan
 
 # clone the repo
 git clone https://github.com/lstein/stable-diffusion.git

--- a/README-Mac-MPS.md
+++ b/README-Mac-MPS.md
@@ -50,15 +50,24 @@ pyenv activate lstein-stable-diffusion
 # OR, 
 # 2. Installing standalone
 # install python 3, git, cmake, protobuf:
-brew install cmake protobuf rust
+brew install cmake protobuf rust unzip
 
 # install miniconda (M1 arm64 version):
 curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o Miniconda3-latest-MacOSX-arm64.sh
 /bin/bash Miniconda3-latest-MacOSX-arm64.sh
 
-
 # EITHER WAY,
 # continue from here
+
+# download and install Real-ESRGAN
+REALESRGAN_GITHUB_URL="https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.5.0/realesrgan-ncnn-vulkan-20220424-macos.zip"
+REALESRGAN_ARCHIVE="realesrgan.zip"
+REALESRGAN_PATH="realesrgan"
+
+curl $REALESRGAN_GITHUB_URL -o $REALESRGAN_ARCHIVE
+unzip $REALESRGAN_ARCHIVE
+rm $REALESRGAN_ARCHIVE
+chmod u+x $REALESRGAN_PATH/realesrgan-ncnn-vulkan
 
 # clone the repo
 git clone https://github.com/lstein/stable-diffusion.git

--- a/ldm/gfpgan/gfpgan_tools.py
+++ b/ldm/gfpgan/gfpgan_tools.py
@@ -160,11 +160,15 @@ def real_esrgan_upscale(image, strength, upsampler_scale, seed, outdir=None):
             '-s', str(upsampler_scale)
         ]
 
-        if upsampler_scale > 2:
+        # Apply realesrgan-x4plus when x4 is selected.
+        # `realesrgan-x4plus` provides a slightly better rendering
+        # than the default model.
+        if upsampler_scale == 4:
             cmd.append('-n')
             cmd.append('realesrgan-x4plus')
 
         try:
+            # Run ../realesrgan/realesrgan-ncnn-vulkan -i <input> -o <ouput> -s [2..4]
             subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/ldm/gfpgan/gfpgan_tools.py
+++ b/ldm/gfpgan/gfpgan_tools.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from PIL import Image
 from scripts.dream import create_argv_parser
+from ldm.dream.devices import choose_torch_device
+import subprocess
 
 arg_parser = create_argv_parser()
 opt = arg_parser.parse_args()
@@ -126,42 +128,86 @@ def _load_gfpgan_bg_upsampler(bg_upsampler, upsampler_scale, bg_tile=400):
 
     return bg_upsampler
 
+def create_tmp_image(image, seed, outdir):
+    from ldm.dream.pngwriter import PngWriter
 
-def real_esrgan_upscale(image, strength, upsampler_scale, seed):
+    pngwriter = PngWriter(outdir)
+    prefix = pngwriter.unique_prefix()
+
+    name = f'tmp_{prefix}.{seed}.png'
+    cwd = os.getcwd()
+    img_path = os.path.join(cwd, outdir, name)
+
+    image.save(img_path)
+    image.close()
+
+    return img_path
+
+def real_esrgan_upscale(image, strength, upsampler_scale, seed, outdir=None):
     print(
         f'>> Real-ESRGAN Upscaling seed:{seed} : scale:{upsampler_scale}x'
     )
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning)
-        warnings.filterwarnings('ignore', category=UserWarning)
+    # Fix the Real-ESRGAN lib that does not work with Apple Silicon
+    # Switch to the local Real-ESRGAN binary
+    if choose_torch_device() == 'mps':
+        img_path = create_tmp_image(image, seed, outdir)
+
+        cmd = [
+            './realesrgan-ncnn-vulkan',
+            '-i', str(img_path),
+            '-o', str(img_path),
+            '-s', str(upsampler_scale)
+        ]
+
+        if upsampler_scale > 2:
+            cmd.append('-n')
+            cmd.append('realesrgan-x4plus')
 
         try:
-            upsampler = _load_gfpgan_bg_upsampler(
-                opt.gfpgan_bg_upsampler, upsampler_scale, opt.gfpgan_bg_tile
-            )
+            subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                cwd="../realesrgan"
+            ).stdout.decode('utf-8')
+
+            res = Image.open(img_path).convert('RGBA')
+            os.remove(img_path)
         except Exception:
             import traceback
-
-            print('>> Error loading Real-ESRGAN:', file=sys.stderr)
+            print('>> Error ESRGAN resize failed:', file=sys.stderr)
             print(traceback.format_exc(), file=sys.stderr)
+    else:
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            warnings.filterwarnings('ignore', category=UserWarning)
 
-    output, img_mode = upsampler.enhance(
-        np.array(image, dtype=np.uint8),
-        outscale=upsampler_scale,
-        alpha_upsampler=opt.gfpgan_bg_upsampler,
-    )
+            try:
+                upsampler = _load_gfpgan_bg_upsampler(
+                    opt.gfpgan_bg_upsampler, upsampler_scale, opt.gfpgan_bg_tile
+                )
+            except Exception:
+                import traceback
 
-    res = Image.fromarray(output)
+                print('>> Error loading Real-ESRGAN:', file=sys.stderr)
+                print(traceback.format_exc(), file=sys.stderr)
 
-    if strength < 1.0:
-        # Resize the image to the new image if the sizes have changed
-        if output.size != image.size:
-            image = image.resize(res.size)
-        res = Image.blend(image, res, strength)
+        output, img_mode = upsampler.enhance(
+            np.array(image, dtype=np.uint8),
+            outscale=upsampler_scale,
+            alpha_upsampler=opt.gfpgan_bg_upsampler,
+        )
 
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-    upsampler = None
+        res = Image.fromarray(output)
+
+        if strength < 1.0:
+            # Resize the image to the new image if the sizes have changed
+            if output.size != image.size:
+                image = image.resize(res.size)
+            res = Image.blend(image, res, strength)
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        upsampler = None
 
     return res


### PR DESCRIPTION
This PR:
- [x] Add support of Real ESRGAN for M1 users.
- [x] Update `README-Mac-MPS.md` to add commands to install Real ESRGAN for M1 users.
- [x] Trivial refactoring for the output folder. Using a "constant" instead of repeating the value a two places in the code
- [x] Add `gfpgan/` in `.gitignore` to avoid pushing GFPGAN model weights

**Test**
This PR has been **manually** tested to generate x2 and x4 upscaling via Real ESRGAN, with and without GFPGAN. 