### PR TITLE
Add Python requirements for Mac so it can be run without Conda

### DIFF
--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -1,0 +1,33 @@
+--pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+
+albumentations==1.2.1
+coloredlogs==15.0.1
+einops==0.4.1
+grpcio==1.47.0
+humanfriendly
+imageio-ffmpeg==0.4.7
+imageio==2.21.2
+imgaug==0.4.0
+kornia==0.6.7
+mpmath==1.2.1
+numpy==1.23.2
+omegaconf==2.1.1
+onnx==1.12.0
+onnxruntime==1.12.1
+pudb==2022.1
+pytorch-lightning==1.6.5
+scipy==1.9.1
+streamlit==1.12.2
+sympy==1.10.1
+tensorboard==2.9.0
+transformers==4.21.2
+
+invisible-watermark
+test-tube
+tokenizers
+
+-e git+https://github.com/huggingface/diffusers.git@v0.2.4#egg=diffusers
+-e git+https://github.com/openai/CLIP.git@main#egg=clip
+-e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
+-e git+https://github.com/lstein/k-diffusion.git@master#egg=k-diffusion
+-e .

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 # Copyright (c) 2022 Lincoln D. Stein (https://github.com/lstein)
 
+import os
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
 import argparse
 import shlex
-import os
 import re
 import sys
 import copy
@@ -54,6 +56,7 @@ def main():
         height=height,
         sampler_name=opt.sampler_name,
         weights=weights,
+        precision="full" if opt.full_precision else "autocast",
         full_precision=opt.full_precision,
         config=config,
         grid  = opt.grid,


### PR DESCRIPTION
This pull request adds a `requirements-mac.txt` that be used to install dependencies on a Mac without Conda. It also sets an environment variable that is set in the Conda environment.

You can use it like this:

```
pip install -r requirements-mac.txt
python scripts/dream.py
```

I created this for [this guide](https://replicate.com/blog/run-stable-diffusion-on-m1-mac), and was intending to switch the guide to use this fork.