### PR TITLE
~7% speedup (1.57 to 1.69it/s) from switch to += in ldm.modules.attention

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -235,9 +235,9 @@ class BasicTransformerBlock(nn.Module):
 
     def _forward(self, x, context=None):
         x = x.contiguous() if x.device.type == 'mps' else x
-        x = self.attn1(self.norm1(x)) + x
-        x = self.attn2(self.norm2(x), context=context) + x
-        x = self.ff(self.norm3(x)) + x
+        x += self.attn1(self.norm1(x))
+        x += self.attn2(self.norm2(x), context=context)
+        x += self.ff(self.norm3(x))
         return x
 
 


### PR DESCRIPTION
~7% speedup (1.57 to 1.69it/s) from switch to += in ldm.modules.attention

Tested on 8GB eGPU nvidia setup so YMMV.
512x512 output, max VRAM stays same.