### PR TITLE
Move model.half() before model.to(device) to avoid GPU copy of full model

### DIFF
--- a/README-Mac-MPS.md
+++ b/README-Mac-MPS.md
@@ -32,12 +32,33 @@ While that is downloading, open Terminal and run the following commands one at a
 # install brew (and Xcode command line tools):
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+#
+# Now there are two different routes to get the Python (miniconda) environment up and running:
+# 1. Alongside pyenv
+# 2. No pyenv
+#
+# If you don't know what we are talking about, choose 2.
+# 
+# NOW EITHER DO
+# 1. Installing alongside pyenv 
+
+brew install pyenv-virtualenv # you might have this from before, no problem
+pyenv install anaconda3-latest
+pyenv virtualenv anaconda3-latest lstein-stable-diffusion
+pyenv activate lstein-stable-diffusion
+
+# OR, 
+# 2. Installing standalone
 # install python 3, git, cmake, protobuf:
 brew install cmake protobuf rust
 
 # install miniconda (M1 arm64 version):
 curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o Miniconda3-latest-MacOSX-arm64.sh
 /bin/bash Miniconda3-latest-MacOSX-arm64.sh
+
+
+# EITHER WAY,
+# continue from here
 
 # clone the repo
 git clone https://github.com/lstein/stable-diffusion.git

--- a/README-Mac-MPS.md
+++ b/README-Mac-MPS.md
@@ -28,7 +28,7 @@ First get the weights checkpoint download started - it's big:
 
 While that is downloading, open Terminal and run the following commands one at a time.
 
-```
+```bash
 # install brew (and Xcode command line tools):
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
@@ -43,9 +43,10 @@ While that is downloading, open Terminal and run the following commands one at a
 # 1. Installing alongside pyenv 
 
 brew install pyenv-virtualenv # you might have this from before, no problem
-pyenv install anaconda3-latest
-pyenv virtualenv anaconda3-latest lstein-stable-diffusion
-pyenv activate lstein-stable-diffusion
+pyenv install anaconda3-2022.05
+pyenv virtualenv anaconda3-2022.05
+eval "$(pyenv init -)"
+pyenv activate anaconda3-2022.05
 
 # OR, 
 # 2. Installing standalone

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -324,7 +324,7 @@ class T2I:
                         self.model.encode_first_stage(init_image)
                     ) # move to latent space
 
-                print(f' DEBUG: seed at make_image time ={seed}')
+                #print(f' DEBUG: seed at make_image time ={seed}')
                 make_image = self._img2img(
                     prompt,
                     steps=steps,
@@ -378,7 +378,7 @@ class T2I:
                         if self.device.type == 'mps':
                             x_T = self._get_noise(init_latent,width,height)
                         # make_image will do the equivalent of get_noise itself
-                    print(f' DEBUG: seed at make_image() invocation time ={seed}')
+                    #print(f' DEBUG: seed at make_image() invocation time ={seed}')
                     image = make_image(x_T)
                     results.append([image, seed])
                     if image_callback is not None:

--- a/ldm/simplet2i.py
+++ b/ldm/simplet2i.py
@@ -663,8 +663,6 @@ class T2I:
         sd = pl_sd['state_dict']
         model = instantiate_from_config(config.model)
         m, u = model.load_state_dict(sd, strict=False)
-        model.to(self.device)
-        model.eval()
         if self.full_precision:
             print(
                 'Using slower but more accurate full-precision math (--full_precision)'
@@ -674,6 +672,8 @@ class T2I:
                 '>> Using half precision math. Call with --full_precision to use more accurate but VRAM-intensive full precision.'
             )
             model.half()
+        model.to(self.device)
+        model.eval()
         return model
 
     def _load_img(self, path, width, height, fit=False):


### PR DESCRIPTION
Speeds up initial load by ~1.5s, as tested on 8GB nvidia eGPU setup. Only avoids initial copying, doesn't improve possible image size. Still same max 704x512 before OOM.