### PR TITLE
Revert "Add 3x upscale option on the Web UI"

### DIFF
--- a/static/dream_web/index.html
+++ b/static/dream_web/index.html
@@ -97,7 +97,6 @@
           <select id="upscale_level" name="upscale_level" value="">
             <option value="" selected>None</option>
             <option value="2">2x</option>
-            <option value="3">3x</option>
             <option value="4">4x</option>
           </select>
           <label title="Strength of the esrgan (upscaling) algorithm." for="upscale_strength">Upscale Strength:</label>


### PR DESCRIPTION
Reverts lstein/stable-diffusion#442 to address the bug introduce when upscaling to x3.  (Reference to Issue: https://github.com/lstein/stable-diffusion/issues/487)