### PR TITLE
Keep using float16 in ldm.modules.attention; ~12% speed up and less VRAM

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -193,7 +193,7 @@ class CrossAttention(nn.Module):
             sim.masked_fill_(~mask, max_neg_value)
 
         # attention, what we cannot get enough of
-        attn = sim.softmax(dim=-1)
+        attn = sim.softmax(dim=-1, dtype=sim.dtype)
 
         out = einsum('b i j, b j d -> b i d', attn, v)
         out = rearrange(out, '(b h) n d -> b n (h d)', h=h)


### PR DESCRIPTION
Tested on nvidia eGPU setup so YMMV with the default half precision math. Speed from 1.69it/s to 1.89it/s and max VRAM from 4.44G to 3.37G for generating 512x512 images. Measured after applying a separate PR #484 Move model.half() before model.to(device)