### PR TITLE
Keep using float16 in ldm.modules.attention; ~12% speed up and less VRAM

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -181,7 +181,7 @@ class CrossAttention(nn.Module):
         q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h=h), (q_in, k_in, v_in))
         del q_in, k_in, v_in
 
-        r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device)
+        r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
 
         if device_type == 'mps':
             mem_free_total = psutil.virtual_memory().available
@@ -213,7 +213,7 @@ class CrossAttention(nn.Module):
             end = i + slice_size
             s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k) * self.scale
 
-            s2 = s1.softmax(dim=-1)
+            s2 = s1.softmax(dim=-1, dtype=r1.dtype)
             del s1
 
             r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)


### PR DESCRIPTION
Tested on nvidia eGPU setup so YMMV with the default half precision math. Speed from ~1.69it/s to ~1.89it/s and max VRAM from 3.90G to 3.37G for generating 512x512 images.

Basically same change as my other pull request but adapted for the development branch. It works, and I could generate 960x960 with a 8GB card, though slowly.