### PR TITLE
revert inadvertent change of conda env name

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: sd-ldm
+name: ldm
 channels:
   - pytorch
   - defaults


### PR DESCRIPTION
This is a hot fix onto main. While debugging training, I inadvertently changed the environment name from "ldm" to "sd-ldm" in environment.yaml. This messes up the documentation, so I'm reverting it.