### PR TITLE
web server does not supply embiggen options yet

### DIFF
--- a/ldm/dream/pngwriter.py
+++ b/ldm/dream/pngwriter.py
@@ -73,9 +73,9 @@ class PromptFormatter:
             switches.append(f'-G{opt.gfpgan_strength}')
         if opt.upscale:
             switches.append(f'-U {" ".join([str(u) for u in opt.upscale])}')
-        if opt.embiggen:
+        if hasattr(opt, 'embiggen') and opt.embiggen:
             switches.append(f'-embiggen {" ".join([str(u) for u in opt.embiggen])}')
-        if opt.embiggen_tiles:
+        if hasattr(opt, 'embiggen_tiles') and opt.embiggen_tiles:
             switches.append(f'-embiggen_tiles {" ".join([str(u) for u in opt.embiggen_tiles])}')
         if opt.variation_amount > 0:
             switches.append(f'-v{opt.variation_amount}')


### PR DESCRIPTION
Fixes web server vs. embiggen issue mentioned in passing at https://github.com/lstein/stable-diffusion/issues/526#issuecomment-1244877836 by making `embiggen` and `embiggen_tiles` optional in ldm/dream/pngwriter.py: https://github.com/lstein/stable-diffusion/blob/a18d0b9ef1feddcf061b861f356c7711ca40e9bb/ldm/dream/pngwriter.py#L76.

```
[...]
File "[...]\stable-diffusion\ldm\dream\server.py", line 221, in do_POST
    self.model.prompt2image(**vars(opt), step_callback=image_progress, image_callback=image_done)
  File "[...]\stable-diffusion\ldm\generate.py", line 327, in prompt2image
    results = generator.generate(
  File "[...]\stable-diffusion\ldm\dream\generator\base.py", line 73, in generate
    image_callback(image, seed)
  File "[...]\stable-diffusion\ldm\dream\server.py", line 163, in image_done
    normalized_prompt = PromptFormatter(self.model, iter_opt).normalize_prompt()
  File "[...]\stable-diffusion\ldm\dream\pngwriter.py", line 76, in normalize_prompt
    if opt.embiggen:
AttributeError: 'Namespace' object has no attribute 'embiggen'
```