### PR TITLE
Update dream.py. k_euler_a and k_dpm_2_a M1 fix

### DIFF
--- a/ldm/generate.py
+++ b/ldm/generate.py
@@ -28,6 +28,24 @@ from ldm.dream.image_util          import InitImageResizer
 from ldm.dream.devices             import choose_torch_device
 from ldm.dream.conditioning        import get_uc_and_c
 
+def fix_func(orig):
+    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        def new_func(*args, **kw):
+            device = kw.get("device", "mps")
+            kw["device"]="cpu"
+            return orig(*args, **kw).to(device)
+        return new_func
+    return orig
+
+torch.rand = fix_func(torch.rand)
+torch.rand_like = fix_func(torch.rand_like)
+torch.randn = fix_func(torch.randn)
+torch.randn_like = fix_func(torch.randn_like)
+torch.randint = fix_func(torch.randint)
+torch.randint_like = fix_func(torch.randint_like)
+torch.bernoulli = fix_func(torch.bernoulli)
+torch.multinomial = fix_func(torch.multinomial)
+
 """Simplified text to image API for stable diffusion/latent diffusion
 
 Example Usage:

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -14,12 +14,30 @@ from ldm.dream.pngwriter import PngWriter, PromptFormatter
 from ldm.dream.server import DreamServer, ThreadingDreamServer
 from ldm.dream.image_util import make_grid
 from omegaconf import OmegaConf
+import torch
 
 # Placeholder to be replaced with proper class that tracks the
 # outputs and associates with the prompt that generated them.
 # Just want to get the formatting look right for now.
 output_cntr = 0
 
+def fix_func(orig):
+    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        def new_func(*args, **kw):
+            device = kw.get("device", "mps")
+            kw["device"]="cpu"
+            return orig(*args, **kw).to(device)
+        return new_func
+    return orig
+
+torch.rand = fix_func(torch.rand)
+torch.rand_like = fix_func(torch.rand_like)
+torch.randn = fix_func(torch.randn)
+torch.randn_like = fix_func(torch.randn_like)
+torch.randint = fix_func(torch.randint)
+torch.randint_like = fix_func(torch.randint_like)
+torch.bernoulli = fix_func(torch.bernoulli)
+torch.multinomial = fix_func(torch.multinomial)
 
 def main():
     """Initialize command-line parsers and the diffusion model"""

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -14,30 +14,11 @@ from ldm.dream.pngwriter import PngWriter, PromptFormatter
 from ldm.dream.server import DreamServer, ThreadingDreamServer
 from ldm.dream.image_util import make_grid
 from omegaconf import OmegaConf
-import torch
 
 # Placeholder to be replaced with proper class that tracks the
 # outputs and associates with the prompt that generated them.
 # Just want to get the formatting look right for now.
 output_cntr = 0
-
-def fix_func(orig):
-    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-        def new_func(*args, **kw):
-            device = kw.get("device", "mps")
-            kw["device"]="cpu"
-            return orig(*args, **kw).to(device)
-        return new_func
-    return orig
-
-torch.rand = fix_func(torch.rand)
-torch.rand_like = fix_func(torch.rand_like)
-torch.randn = fix_func(torch.randn)
-torch.randn_like = fix_func(torch.randn_like)
-torch.randint = fix_func(torch.randint)
-torch.randint_like = fix_func(torch.randint_like)
-torch.bernoulli = fix_func(torch.bernoulli)
-torch.multinomial = fix_func(torch.multinomial)
 
 def main():
     """Initialize command-line parsers and the diffusion model"""


### PR DESCRIPTION
Make results reproducible (so runs with the same seed produce the same result). Implements fix by @wbowling referenced in https://github.com/lstein/stable-diffusion/issues/397#issuecomment-1240679294
Example: `"banana sushi" -s50 -W512 -H512 -C7.5 -Ak_euler_a -S618376249`
Before
<img width="378" alt="Screenshot 2022-09-14 at 23 27 27" src="https://user-images.githubusercontent.com/50542132/190265752-bc677ef2-3666-46ec-9fd1-c1e61f181a00.png">
After
<img width="378" alt="Screenshot 2022-09-14 at 23 27 45" src="https://user-images.githubusercontent.com/50542132/190265789-e4455d44-26ef-473b-abcf-dd9aa760f8c5.png">

Fix should be ignored in non-MPS devices, but test to make sure.