### PR TITLE
Make API return error before raising error again

### DIFF
--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -247,6 +247,15 @@ class DreamServer(BaseHTTPRequestHandler):
         except CanceledException:
             print(f"Canceled.")
             return
+        except Exception as e:
+            print("Error happened")
+            print(e)
+            self.wfile.write(bytes(json.dumps(
+                {'event': 'error',
+                 'message': str(e),
+                 'type': e.__class__.__name__}
+            ) + '\n',"utf-8"))
+            raise e
 
 
 class ThreadingDreamServer(ThreadingHTTPServer):


### PR DESCRIPTION
This change makes it so any API clients can show the same error as what happens in the terminal where you run the API. Useful for various WebUIs to display more helpful error messages to users.

As an example, setting `cfg_scale` to `1` would return nothing as the response body when making HTTP requests. The terminal window would print `AssertionError: CFG_Scale (-C) must be >1.0` together with a stack trace though, but only useful for whoever has access to the terminal window itself.

With this change, sending a request with `cfg_scale` set to `1`, it now returns the following response body before closing the connection:

```json
{"event": "error",
 "message": "CFG_Scale (-C) must be >1.0",
 "type": "AssertionError"}
```

It still raises the exception after printing it, so everything works as before (printing the exception in the terminal too) and in the future, catches can be made further up the stack if necessary. 

This is probably the first piece of Python code I've ever written, so please let me know if I did something heroically wrong, as I have no idea about Python idioms.