### PR TITLE
separate toc by disabling toc.integrate

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ copyright: Copyright &copy; 2022 Lincoln D. Stein <lincoln.stein@gmail.com>
 # Configuration
 theme:
   name: material
-  features:
-    - toc.integrate
+  # features:
+  #   - toc.integrate
   palette:
     - media: '(prefers-color-scheme: light)'
       primary: blue


### PR DESCRIPTION
this way the leftside menu does not look so bloated and users can
find what they are looking for much faster