### PR TITLE
Zero-pad intermediate image file names

### DIFF
--- a/ldm/dream/server.py
+++ b/ldm/dream/server.py
@@ -207,7 +207,8 @@ class DreamServer(BaseHTTPRequestHandler):
             nonlocal step_index
             if opt.progress_images and step % 5 == 0 and step < opt.steps - 1:
                 image = self.model.sample_to_image(sample)
-                name = f'{prefix}.{opt.seed}.{step_index}.png'
+                step_index_padded = str(step_index).rjust(len(str(opt.steps)), '0')
+                name = f'{prefix}.{opt.seed}.{step_index_padded}.png'
                 metadata = f'{opt.prompt} -S{opt.seed} [intermediate]'
                 path = step_writer.save_image_and_prompt_to_png(image, metadata, name)
                 step_index += 1


### PR DESCRIPTION
This keeps intermediate image filenames in order:

    000010.None.01.png
    000010.None.02.png
    000010.None.03.png
    000010.None.04.png
    000010.None.05.png
    000010.None.06.png
    000010.None.07.png
    000010.None.08.png
    000010.None.09.png
    000010.None.10.png

rather than:

    000010.None.1.png
    000010.None.10.png
    000010.None.2.png
    000010.None.3.png
    000010.None.4.png
    000010.None.5.png
    000010.None.6.png
    000010.None.7.png
    000010.None.8.png
    000010.None.9.png

