### PR TITLE
Development

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -147,15 +147,12 @@ def handle_request_all_images():
     paths.sort(key=lambda x: os.path.getmtime(x))
     image_array = []
     for path in paths:
-        image = Image.open(path)
-        metadata = {}
-        if 'Dream' in image.info:
-            try:
-                metadata = vars(parser.parse_args(shlex.split(image.info['Dream'])))
-            except SystemExit:
-                # TODO: Unable to parse metadata, ignore it for now,
-                # this can happen when metadata is missing a prompt
-                pass
+        # image = Image.open(path)
+        all_metadata = retrieve_metadata(path)
+        if 'Dream' in all_metadata and not all_metadata['sd-metadata']:
+            metadata = vars(parser.parse_args(shlex.split(all_metadata['Dream'])))
+        else:
+            metadata = all_metadata['sd-metadata']
         image_array.append({'path': path, 'metadata': metadata})
     return make_response("OK", data=image_array)
 
@@ -308,7 +305,7 @@ def save_image(image, parameters, output_dir, step_index=None, postprocessing=Fa
 
     command = parameters_to_command(parameters)
 
-    path = pngwriter.save_image_and_prompt_to_png(image, command, filename)
+    path = pngwriter.save_image_and_prompt_to_png(image, command, parameters, filename)
 
     return path
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -19,7 +19,8 @@ from uuid import uuid4
 from ldm.gfpgan.gfpgan_tools import real_esrgan_upscale
 from ldm.gfpgan.gfpgan_tools import run_gfpgan
 from ldm.generate import Generate
-from ldm.dream.pngwriter import PngWriter
+from ldm.dream.pngwriter import PngWriter, retrieve_metadata
+
 from modules.parameters import parameters_to_command, create_cmd_parser
 
 

--- a/ldm/dream/pngwriter.py
+++ b/ldm/dream/pngwriter.py
@@ -47,7 +47,8 @@ class PngWriter:
         metadata stored there, as a dict
         '''
         path = os.path.join(self.outdir,img_basename)
-        return retrieve_metadata(path)
+        all_metadata = retrieve_metadata(path)
+        return all_metadata['sd-metadata']
 
 def retrieve_metadata(img_path):
     '''
@@ -55,6 +56,7 @@ def retrieve_metadata(img_path):
     metadata stored there, as a dict
     '''
     im = Image.open(img_path)
-    md = im.text.get('sd-metadata',{})
-    return json.loads(md)
+    md = im.text.get('sd-metadata', '{}')
+    dream_prompt = im.text.get('Dream', '')
+    return {'sd-metadata': json.loads(md), 'Dream': dream_prompt}
 

--- a/scripts/sd-metadata.py
+++ b/scripts/sd-metadata.py
@@ -13,7 +13,7 @@ filenames = sys.argv[1:]
 for f in filenames:
     try:
         metadata = retrieve_metadata(f)
-        print(f'{f}:\n',json.dumps(metadata, indent=4))
+        print(f'{f}:\n',json.dumps(metadata['sd-metadata'], indent=4))
     except FileNotFoundError:
         sys.stderr.write(f'{f} not found\n')
         continue


### PR DESCRIPTION
Fixes two bugs reported here: https://github.com/lstein/stable-diffusion/issues/619#issue-1376284608


1. Reproducer: `python backend/server.py`
```python
Traceback (most recent call last):
  File "C:\Users\quaestor\Source\stable-diffusion-stable\backend\server.py", line 22, in <module>
    from ldm.dream.pngwriter import PngWriter, PromptFormatter
ImportError: cannot import name 'PromptFormatter' from 'ldm.dream.pngwriter' (c:\users\quaestor\source\stable-diffusion-stable\ldm\dream\pngwriter.py)
```

Fix: `PromptFormatter` is an extraneous dependency, removed.


2. Reproducer: attempt to generate an image
```python
Traceback (most recent call last):
  File "C:\Users\quaestor\Source\stable-diffusion-stable\backend\server.py", line 375, in generate_images
    model.prompt2image(
  File "c:\users\quaestor\source\stable-diffusion-stable\ldm\generate.py", line 344, in prompt2image
    results = generator.generate(
  File "c:\users\quaestor\source\stable-diffusion-stable\ldm\dream\generator\base.py", line 73, in generate
    image_callback(image, seed)
  File "C:\Users\quaestor\Source\stable-diffusion-stable\backend\server.py", line 364, in image_done
    path = save_image(image, all_parameters, result_path, postprocessing=postprocessing)
  File "C:\Users\quaestor\Source\stable-diffusion-stable\backend\server.py", line 310, in save_image
    path = pngwriter.save_image_and_prompt_to_png(image, command, filename)
TypeError: PngWriter.save_image_and_prompt_to_png() missing 1 required positional argument: 'name'
```

Fix: Corrects function call - function had changed in recent work on metadata. 

3. Fixed metadata reading. Modified `ldm.dream.pngwriter.retrieve_metadata` to also grab the old `Dream` REPL command. Updated references to `retrieve_metadata` so they are not affected. This is necessary for the new UI to fall back to reconstructing metadata from the REPL command if the new `sd-metadata` field is unpopulated.