### PR TITLE
Bug Fixes: generate and dream refactor

### DIFF
--- a/ldm/dream/args.py
+++ b/ldm/dream/args.py
@@ -105,6 +105,7 @@ class Args(object):
         try:
             elements = shlex.split(command)
         except ValueError:
+            import sys, traceback
             print(traceback.format_exc(), file=sys.stderr)
             return
         switches = ['']
@@ -267,6 +268,17 @@ class Args(object):
             help='Indicates which diffusion model to load. (currently "stable-diffusion-1.4" (default) or "laion400m")',
         )
         model_group.add_argument(
+            '--sampler',
+            '-A',
+            '-m',
+            dest='sampler_name',
+            type=str,
+            choices=SAMPLER_CHOICES,
+            metavar='SAMPLER_NAME',
+            help=f'Switch to a different sampler. Supported samplers: {", ".join(SAMPLER_CHOICES)}',
+            default='k_lms',
+        )
+        model_group.add_argument(
             '-F',
             '--full_precision',
             dest='full_precision',
@@ -386,14 +398,12 @@ class Args(object):
             '--width',
             type=int,
             help='Image width, multiple of 64',
-            default=512
         )
         render_group.add_argument(
             '-H',
             '--height',
             type=int,
             help='Image height, multiple of 64',
-            default=512,
         )
         render_group.add_argument(
             '-C',
@@ -429,7 +439,6 @@ class Args(object):
             choices=SAMPLER_CHOICES,
             metavar='SAMPLER_NAME',
             help=f'Switch to a different sampler. Supported samplers: {", ".join(SAMPLER_CHOICES)}',
-            default='k_lms',
         )
         render_group.add_argument(
             '-t',

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -123,7 +123,7 @@ def main_loop(gen, opt, infile):
         if command.startswith(('#', '//')):
             continue
 
-        if command.startswith('q '):
+        if len(command.strip()) == 1 and command.startswith('q'):
             done = True
             break
 
@@ -138,7 +138,7 @@ def main_loop(gen, opt, infile):
             parser.print_help()
             continue
         if len(opt.prompt) == 0:
-            print('Try again with a prompt!')
+            print('\nTry again with a prompt!')
             continue
 
         # retrieve previous value!
@@ -191,14 +191,14 @@ def main_loop(gen, opt, infile):
             if not os.path.exists(opt.outdir):
                 os.makedirs(opt.outdir)
             current_outdir = opt.outdir
-        elif prompt_as_dir:
+        elif opt.prompt_as_dir:
             # sanitize the prompt to a valid folder name
             subdir = path_filter.sub('_', opt.prompt)[:name_max].rstrip(' .')
 
             # truncate path to maximum allowed length
             # 27 is the length of '######.##########.##.png', plus two separators and a NUL
             subdir = subdir[:(path_max - 27 - len(os.path.abspath(opt.outdir)))]
-            current_outdir = os.path.join(outdir, subdir)
+            current_outdir = os.path.join(opt.outdir, subdir)
 
             print('Writing files to directory: "' + current_outdir + '"')
 
@@ -206,7 +206,7 @@ def main_loop(gen, opt, infile):
             if not os.path.exists(current_outdir):
                 os.makedirs(current_outdir)
         else:
-            current_outdir = outdir
+            current_outdir = opt.outdir
 
         # Here is where the images are actually generated!
         last_results = []


### PR DESCRIPTION
A bug fix patch for things that broke with the generate and dream refactor. #534 

**Fixes:**

- Fixed `q` not working to exit the dream command line.
- Added `--sampler' to model_group too. This is an important argument that allows scripts to run a default sampler at boot.
- Fixed `generate` ignoring the width and height from the config file.
- Fixed some missing imports
- Fixed some opts not ported over correctly.


**ToDo:**

- **CRITICAL** >>> 2nd Prompt is Broken. The first prompt works. The 2nd prompt crashes. @lstein Please look into this.

---

This bug fix patch can be merged once all the bugs are fixed.