### PR TITLE
toil(docs): readme - remove remaining markdown warts, HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
-<h1 align='center'><b>Stable Diffusion Dream Script</b></h1>
+<div align="center">
 
-<p align='center'>
-    <img src="docs/assets/logo.png"/>
-</p>
+# Stable Diffusion Dream Script
 
-<p align="center">
-    <a href="https://github.com/lstein/stable-diffusion/releases"><img src="https://flat.badgen.net/github/release/lstein/stable-diffusion/development?icon=github" alt="release"/></a>
-    <a href="https://github.com/lstein/stable-diffusion/stargazers"><img src="https://flat.badgen.net/github/stars/lstein/stable-diffusion?icon=github" alt="stars"/></a>
-    <a href="https://useful-forks.github.io/?repo=lstein%2Fstable-diffusion"><img src="https://flat.badgen.net/github/forks/lstein/stable-diffusion?icon=github" alt="forks"/></a>
-    <br />
-    <a href="https://github.com/lstein/stable-diffusion/actions/workflows/test-dream-conda.yml"><img src="https://flat.badgen.net/github/checks/lstein/stable-diffusion/main?label=CI%20status%20on%20main&cache=900&icon=github" alt="CI status on main"/></a>
-    <a href="https://github.com/lstein/stable-diffusion/actions/workflows/test-dream-conda.yml"><img src="https://flat.badgen.net/github/checks/lstein/stable-diffusion/development?label=CI%20status%20on%20dev&cache=900&icon=github" alt="CI status on dev"/></a>
-    <a href="https://github.com/lstein/stable-diffusion/commits/development"><img src="https://flat.badgen.net/github/last-commit/lstein/stable-diffusion/development?icon=github&color=yellow&label=last%20dev%20commit&cache=900" alt="last-dev-commit"/></a>
-    <br />
-    <a href="https://github.com/lstein/stable-diffusion/issues?q=is%3Aissue+is%3Aopen"><img src="https://flat.badgen.net/github/open-issues/lstein/stable-diffusion?icon=github" alt="open-issues"/></a>
-    <a href="https://github.com/lstein/stable-diffusion/pulls?q=is%3Apr+is%3Aopen"><img src="https://flat.badgen.net/github/open-prs/lstein/stable-diffusion?icon=github" alt="open-prs"/></a>
-</p>
+![project logo](docs/assets/logo.png)
+
+[![latest release badge]][latest release link] [![github stars badge]][github stars link] [![github forks badge]][github forks link]
+
+[![CI checks on main badge]][CI checks on main link] [![CI checks on dev badge]][CI checks on dev link] [![latest commit to dev badge]][latest commit to dev link]
+
+[![github open issues badge]][github open issues link] [![github open prs badge]][github open prs link]
+
+[CI checks on dev badge]: https://flat.badgen.net/github/checks/lstein/stable-diffusion/development?label=CI%20status%20on%20dev&cache=900&icon=github
+[CI checks on dev link]: https://github.com/lstein/stable-diffusion/actions/workflows/test-dream-conda.yml
+[CI checks on main badge]: https://flat.badgen.net/github/checks/lstein/stable-diffusion/main?label=CI%20status%20on%20main&cache=900&icon=github
+[CI checks on main link]: https://github.com/lstein/stable-diffusion/actions/workflows/test-dream-conda.yml
+[github forks badge]: https://flat.badgen.net/github/forks/lstein/stable-diffusion?icon=github
+[github forks link]: https://useful-forks.github.io/?repo=lstein%2Fstable-diffusion
+[github open issues badge]: https://flat.badgen.net/github/open-issues/lstein/stable-diffusion?icon=github
+[github open issues link]: https://github.com/lstein/stable-diffusion/issues?q=is%3Aissue+is%3Aopen
+[github open prs badge]: https://flat.badgen.net/github/open-prs/lstein/stable-diffusion?icon=github
+[github open prs link]: https://github.com/lstein/stable-diffusion/pulls?q=is%3Apr+is%3Aopen
+[github stars badge]: https://flat.badgen.net/github/stars/lstein/stable-diffusion?icon=github
+[github stars link]: https://github.com/lstein/stable-diffusion/stargazers
+[latest commit to dev badge]: https://flat.badgen.net/github/last-commit/lstein/stable-diffusion/development?icon=github&color=yellow&label=last%20dev%20commit&cache=900
+[latest commit to dev link]: https://github.com/lstein/stable-diffusion/commits/development
+[latest release badge]: https://flat.badgen.net/github/release/lstein/stable-diffusion/development?icon=github
+[latest release link]: https://github.com/lstein/stable-diffusion/releases
+</div>
 
 This is a fork of [CompVis/stable-diffusion](https://github.com/CompVis/stable-diffusion), the open
 source text-to-image generator. It provides a streamlined process with various new features and
@@ -26,7 +37,7 @@ _Note: This fork is rapidly evolving. Please use the
 [Issues](https://github.com/lstein/stable-diffusion/issues) tab to report bugs and make feature
 requests. Be sure to use the provided templates. They will help aid diagnose issues faster._
 
-**Table of Contents**
+## Table of Contents
 
 1. [Installation](#installation)
 2. [Hardware Requirements](#hardware-requirements)
@@ -38,38 +49,38 @@ requests. Be sure to use the provided templates. They will help aid diagnose iss
 8. [Support](#support)
 9. [Further Reading](#further-reading)
 
-## Installation
+### Installation
 
 This fork is supported across multiple platforms. You can find individual installation instructions
 below.
 
-- ### [Linux](docs/installation/INSTALL_LINUX.md)
+- #### [Linux](docs/installation/INSTALL_LINUX.md)
 
-- ### [Windows](docs/installation/INSTALL_WINDOWS.md)
+- #### [Windows](docs/installation/INSTALL_WINDOWS.md)
 
-- ### [Macintosh](docs/installation/INSTALL_MAC.md)
+- #### [Macintosh](docs/installation/INSTALL_MAC.md)
 
-## Hardware Requirements
+### Hardware Requirements
 
-**System**
+#### System
 
 You wil need one of the following:
 
 - An NVIDIA-based graphics card with 4 GB or more VRAM memory.
 - An Apple computer with an M1 chip.
 
-**Memory**
+#### Memory
 
 - At least 12 GB Main Memory RAM.
 
-**Disk**
+#### Disk
 
 - At least 6 GB of free disk space for the machine learning model, Python, and all its dependencies.
 
-**Note**
-
-If you are have a Nvidia 10xx series card (e.g. the 1080ti), please run the dream script in
-full-precision mode as shown below.
+> Note
+>
+> If you have an Nvidia 10xx series card (e.g. the 1080ti), please run the dream script in
+> full-precision mode as shown below.
 
 Similarly, specify full-precision mode on Apple M1 hardware.
 
@@ -79,43 +90,30 @@ To run in full-precision mode, start `dream.py` with the `--full_precision` flag
 (ldm) ~/stable-diffusion$ python scripts/dream.py --full_precision
 ```
 
-## Features
+### Features
 
-### Major Features
+#### Major Features
 
-- #### [Interactive Command Line Interface](docs/features/CLI.md)
+- [Interactive Command Line Interface](docs/features/CLI.md)
+- [Image To Image](docs/features/IMG2IMG.md)
+- [Inpainting Support](docs/features/INPAINTING.md)
+- [GFPGAN and Real-ESRGAN Support](docs/features/UPSCALE.md)
+- [Seamless Tiling](docs/features/OTHER.md#seamless-tiling)
+- [Google Colab](docs/features/OTHER.md#google-colab)
+- [Web Server](docs/features/WEB.md)
+- [Reading Prompts From File](docs/features/OTHER.md#reading-prompts-from-a-file)
+- [Shortcut: Reusing Seeds](docs/features/OTHER.md#shortcuts-reusing-seeds)
+- [Weighted Prompts](docs/features/OTHER.md#weighted-prompts)
+- [Variations](docs/features/VARIATIONS.md)
+- [Personalizing Text-to-Image Generation](docs/features/TEXTUAL_INVERSION.md)
+- [Simplified API for text to image generation](docs/features/OTHER.md#simplified-api)
 
-- #### [Image To Image](docs/features/IMG2IMG.md)
+#### Other Features
 
-- #### [Inpainting Support](docs/features/INPAINTING.md)
+- [Creating Transparent Regions for Inpainting](docs/features/INPAINTING.md#creating-transparent-regions-for-inpainting)
+- [Preload Models](docs/features/OTHER.md#preload-models)
 
-- #### [GFPGAN and Real-ESRGAN Support](docs/features/UPSCALE.md)
-
-- #### [Seamless Tiling](docs/features/OTHER.md#seamless-tiling)
-
-- #### [Google Colab](docs/features/OTHER.md#google-colab)
-
-- #### [Web Server](docs/features/WEB.md)
-
-- #### [Reading Prompts From File](docs/features/OTHER.md#reading-prompts-from-a-file)
-
-- #### [Shortcut: Reusing Seeds](docs/features/OTHER.md#shortcuts-reusing-seeds)
-
-- #### [Weighted Prompts](docs/features/OTHER.md#weighted-prompts)
-
-- #### [Variations](docs/features/VARIATIONS.md)
-
-- #### [Personalizing Text-to-Image Generation](docs/features/TEXTUAL_INVERSION.md)
-
-- #### [Simplified API for text to image generation](docs/features/OTHER.md#simplified-api)
-
-### Other Features
-
-- #### [Creating Transparent Regions for Inpainting](docs/features/INPAINTING.md#creating-transparent-regions-for-inpainting)
-
-- #### [Preload Models](docs/features/OTHER.md#preload-models)
-
-## Latest Changes
+### Latest Changes
 
 - v1.14 (11 September 2022)
 
@@ -147,12 +145,12 @@ To run in full-precision mode, start `dream.py` with the `--full_precision` flag
 
 For older changelogs, please visit the **[CHANGELOG](docs/features/CHANGELOG.md)**.
 
-## Troubleshooting
+### Troubleshooting
 
 Please check out our **[Q&A](docs/help/TROUBLESHOOT.md)** to get solutions for common installation
 problems and other issues.
 
-## Contributing
+### Contributing
 
 Anyone who wishes to contribute to this project, whether documentation, features, bug fixes, code
 cleanup, testing, or code reviews, is very much encouraged to do so. If you are unfamiliar with how
@@ -164,13 +162,13 @@ important thing is to **make your pull request against the "development" branch*
 "main". This will help keep public breakage to a minimum and will allow you to propose more radical
 changes.
 
-## Contributors
+### Contributors
 
 This fork is a combined effort of various people from across the world.
 [Check out the list of all these amazing people](docs/other/CONTRIBUTORS.md). We thank them for
 their time, hard work and effort.
 
-## Support
+### Support
 
 For support, please use this repository's GitHub Issues tracking service. Feel free to send me an
 email if you use and like the script.
@@ -178,7 +176,7 @@ email if you use and like the script.
 Original portions of the software are Copyright (c) 2020
 [Lincoln D. Stein](https://github.com/lstein)
 
-## Further Reading
+### Further Reading
 
 Please see the original README for more information on this software and underlying algorithm,
 located in the file [README-CompViz.md](docs/other/README-CompViz.md).


### PR DESCRIPTION
Looks like we have to use a *deprecated* AND *obsoleted* HTML mechanism... +1 GitHub 😐

- maintaining the badges in embedded HTML is a P.I.T.A. (and embedding HTML in Markdown is highly discouraged)
- "don't use emphasis for header-like things - use headers"
- links aren't headers

[Preview](https://github.com/tildebyte/stable-diffusion/blob/toil-de-wart-readme-md/README.md)

Signed-off-by: Ben Alkov <ben.alkov@gmail.com>
