### PR TITLE
fix(doc): readme - more meaningful CI badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 [![github open issues badge]][github open issues link] [![github open prs badge]][github open prs link]
 
 [CI checks on dev badge]: https://flat.badgen.net/github/checks/lstein/stable-diffusion/development?label=CI%20status%20on%20dev&cache=900&icon=github
-[CI checks on dev link]: https://github.com/lstein/stable-diffusion/actions/workflows/test-dream-conda.yml
+[CI checks on dev link]: https://github.com/lstein/stable-diffusion/actions?query=branch%3Adevelopment
 [CI checks on main badge]: https://flat.badgen.net/github/checks/lstein/stable-diffusion/main?label=CI%20status%20on%20main&cache=900&icon=github
-[CI checks on main link]: https://github.com/lstein/stable-diffusion/actions/workflows/test-dream-conda.yml
+[CI checks on main link]: https://github.com/lstein/stable-diffusion/actions?query=branch%3Amain
 [github forks badge]: https://flat.badgen.net/github/forks/lstein/stable-diffusion?icon=github
 [github forks link]: https://useful-forks.github.io/?repo=lstein%2Fstable-diffusion
 [github open issues badge]: https://flat.badgen.net/github/open-issues/lstein/stable-diffusion?icon=github


### PR DESCRIPTION
Finally figured it out 😁

[Preview](https://github.com/tildebyte/stable-diffusion/blob/fix-doc-readme-ci-links/README.md)

Signed-off-by: Ben Alkov <ben.alkov@gmail.com>