### PR TITLE
restore ability to save files to directories named after prompt

### DIFF
--- a/ldm/dream/args.py
+++ b/ldm/dream/args.py
@@ -654,6 +654,8 @@ def metadata_loads(metadata):
             # repack the prompt and variations
             image['prompt']     = ','.join([':'.join([x['prompt'],   str(x['weight'])]) for x in image['prompt']])
             image['variations'] = ','.join([':'.join([str(x['seed']),str(x['weight'])]) for x in image['variations']])
+            # fix a bit of semantic drift here
+            image['sampler_name']=image.pop('sampler')
             opt = Args()
             opt._cmd_switches = Namespace(**image)
             results.append(opt)

--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -191,11 +191,7 @@ def main_loop(gen, opt, infile):
             else:
                 opt.with_variations = None
 
-        if opt.outdir:
-            if not os.path.exists(opt.outdir):
-                os.makedirs(opt.outdir)
-            current_outdir = opt.outdir
-        elif opt.prompt_as_dir:
+        if opt.prompt_as_dir:
             # sanitize the prompt to a valid folder name
             subdir = path_filter.sub('_', opt.prompt)[:name_max].rstrip(' .')
 
@@ -210,6 +206,8 @@ def main_loop(gen, opt, infile):
             if not os.path.exists(current_outdir):
                 os.makedirs(current_outdir)
         else:
+            if not os.path.exists(opt.outdir):
+                os.makedirs(opt.outdir)
             current_outdir = opt.outdir
 
         # Here is where the images are actually generated!


### PR DESCRIPTION
The recent args refactor broke the handling of the --prompt_as_dir flag. This restores it.

In addition, there was a bit of semantic drift between the internal configuration variable "sampler_name" and the RFC field "sampler." I did a little workaround so as not to introduce many code changes.