### PR TITLE
Negative / Unconditioned Prompts

### DIFF
--- a/docs/other/CONTRIBUTORS.md
+++ b/docs/other/CONTRIBUTORS.md
@@ -2,15 +2,16 @@
 title: Contributors
 ---
 
-The list of all the amazing people who have contributed to the various features that you get to experience in this fork.
+The list of all the amazing people who have contributed to the various features that you get to
+experience in this fork.
 
 We thank them for all of their time and hard work.
 
-## __Original Author:__
+## **Original Author:**
 
 - [Lincoln D. Stein](mailto:lincoln.stein@gmail.com)
 
-## __Contributions by:__
+## **Contributions by:**
 
 - [Sean McLellan](https://github.com/Oceanswave)
 - [Kevin Gibbons](https://github.com/bakkot)
@@ -52,8 +53,9 @@ We thank them for all of their time and hard work.
 - [Doggettx](https://github.com/doggettx)
 - [Matthias Wild](https://github.com/mauwii)
 - [Kyle Schouviller](https://github.com/kyle0654)
+- [rabidcopy](https://github.com/rabidcopy)
 
-## __Original CompVis Authors:__
+## **Original CompVis Authors:**
 
 - [Robin Rombach](https://github.com/rromb)
 - [Patrick von Platen](https://github.com/patrickvonplaten)
@@ -65,4 +67,5 @@ We thank them for all of their time and hard work.
 
 ---
 
-_If you have contributed and don't see your name on the list of contributors, please let one of the collaborators know about the omission, or feel free to make a pull request._
+_If you have contributed and don't see your name on the list of contributors, please let one of the
+collaborators know about the omission, or feel free to make a pull request._


### PR DESCRIPTION
This is an improved and optimized version of @rabidcopy's PR #637 that implements negative prompting.

## Usage

Any words between a pair of square brackets will try and be ignored by Stable Diffusion's model during generation of images.

```this is a test prompt [not really] to make you understand [cool] how this works.```

In the above statement, the words 'not really cool` will be ignored by Stable Diffusion.

Here's a prompt that depicts what it does.

original prompt: `"A fantastical translucent poney made of water and foam, ethereal, radiant, hyperalism, scottish folklore, digital painting, artstation, concept art, smooth, 8 k frostbite 3 engine, ultra detailed, art by artgerm and greg rutkowski and magali villeneuve" -s 20 -W 512 -H 768 -C 7.5 -A k_euler_a -S 1654590180`

![000001 1654590180](https://user-images.githubusercontent.com/54517381/190882953-0ab26d4c-1176-49f7-83c9-1791f7828196.png)

This one gave me a woman. I don't want a woman in this picture. So I just type ---

new prompt: `"A fantastical translucent poney made of water and foam, ethereal, radiant, hyperalism, scottish folklore, digital painting, artstation, concept art, smooth, 8 k frostbite 3 engine, ultra detailed, art by artgerm and greg rutkowski and magali villeneuve [woman]" -s 20 -W 512 -H 768 -C 7.5 -A k_euler_a -S 1654590180`

![000002 1654590180](https://user-images.githubusercontent.com/54517381/190882968-d586ac4f-b1fd-4db9-9994-c16f93570267.png)

Awesome. But I don't want the image to be blue.

new prompt: `"A fantastical translucent poney made of water and foam, ethereal, radiant, hyperalism, scottish folklore, digital painting, artstation, concept art, smooth, 8 k frostbite 3 engine, ultra detailed, art by artgerm and greg rutkowski and magali villeneuve [woman blue]" -s 20 -W 512 -H 768 -C 7.5 -A k_euler_a -S 1654590180`

![000003 1654590180](https://user-images.githubusercontent.com/54517381/190882981-71be0961-aeef-47c1-9728-26dfac8421c9.png)

Perfect. But I don't want that stupid saddle. I want the horse to be free.

new prompt: `"A fantastical translucent poney made of water and foam, ethereal, radiant, hyperalism, scottish folklore, digital painting, artstation, concept art, smooth, 8 k frostbite 3 engine, ultra detailed, art by artgerm and greg rutkowski and magali villeneuve [woman blue saddle]" -s 20 -W 512 -H 768 -C 7.5 -A k_euler_a -S 1654590180`

![000004 1654590180](https://user-images.githubusercontent.com/54517381/190882992-fb89a27a-316e-4c9a-9788-76b3c7b1dff6.png)

Perfect.

As you can see, there is a ton of potential with this and now it is implemented in the simplest way possible.

### **Notes**

- The only requirement for words to be ignored is that they are in between a pair of square brackets.
- You can provide multiple words within the same bracket.
- You can provide multiple brackets with multiple words in different places of your prompt. That works just fine.

I've done quite a bit of testing and it works great as long as the words you are omitting are actual difference makers to your prompt.

@lstein This should be good to go. Simple code that breaks almost nothing. And seems to be working quite awesome. Tagging you coz you said you might do it yourself.

---

Co-Authored-By: @rabidcopy <8052832+rabidcopy@users.noreply.github.com>
