### PR TITLE
fix(scripts): dream.py typo

### DIFF
--- a/scripts/dream.py
+++ b/scripts/dream.py
@@ -269,7 +269,7 @@ def main_loop(gen, opt, infile):
                 filename   = f'{prefix}.{first_seed}.png'
                 formatted_dream_prompt  = opt.dream_prompt_str(seed=first_seed,grid=True,iterations=len(grid_images))
                 formatted_dream_prompt += f' # {grid_seeds}'
-                metadata = metadata.dumps(
+                metadata = metadata_dumps(
                     opt,
                     seeds      = grid_seeds,
                     weights    = gen.weights,


### PR DESCRIPTION
Stumbled on this while playing with `blue`, and thought it looked like a typo.

Introduced in 239f41f https://github.com/lstein/stable-diffusion/blob/239f41f3e0027900ee73196ac89850a9d172c0e9/scripts/dream.py#L274

Signed-off-by: Ben Alkov <ben.alkov@gmail.com>